### PR TITLE
Added Culture tests and use current culture (can be set)

### DIFF
--- a/NLog.Web.Tests/LayoutRenderers/AspNetSessionValueLayoutRendererTests.cs
+++ b/NLog.Web.Tests/LayoutRenderers/AspNetSessionValueLayoutRendererTests.cs
@@ -6,6 +6,8 @@ using System.Reflection;
 using System.Web;
 using System.Web.SessionState;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NLog.LayoutRenderers;
+using NLog.Layouts;
 using NLog.Web.LayoutRenderers;
 
 namespace NLog.Web.Tests.LayoutRenderers
@@ -151,6 +153,28 @@ namespace NLog.Web.Tests.LayoutRenderers
             ExecTest("a", o, "", appSettingLayoutRenderer);
         }
 
+
+        [TestMethod()]
+        public void SessionWithPadding()
+        {
+            Layout layout = "${aspnet-session:a.b:padding=5:evaluateAsNestedProperties=true}";
+
+            var o = new { b = "c" };
+            //set in "a"
+            ExecTest("a", o, "    c", layout);
+        }
+
+
+        [TestMethod()]
+        public void SessionWithCulture()
+        {
+            Layout layout = "${aspnet-session:a.b:culture=en-GB:evaluateAsNestedProperties=true}";
+
+            var o = new { b = new DateTime(2015,11,24) };
+            //set in "a"
+            ExecTest("a", o, "    c", layout);
+        }
+
         /// <summary>
         /// set in Session and test
         /// </summary>
@@ -158,10 +182,26 @@ namespace NLog.Web.Tests.LayoutRenderers
         /// <param name="value">set this value</param>
         /// <param name="expected">expected</param>
         /// <param name="appSettingLayoutRenderer"></param>
-        private void ExecTest(string key, object value, object expected, AspNetSessionValueLayoutRenderer appSettingLayoutRenderer)
+        ///  <remarks>IRenderable is internal</remarks>
+        private void ExecTest(string key, object value, object expected, Layout appSettingLayoutRenderer)
         {
+            Session[key] = value;
 
+            var rendered = appSettingLayoutRenderer.Render(LogEventInfo.CreateNullEvent());
 
+            Assert.AreEqual(expected, rendered);
+        }
+
+        /// <summary>
+        /// set in Session and test
+        /// </summary>
+        /// <param name="key">set with this key</param>
+        /// <param name="value">set this value</param>
+        /// <param name="expected">expected</param>
+        /// <param name="appSettingLayoutRenderer"></param>
+        /// <remarks>IRenderable is internal</remarks>
+        private void ExecTest(string key, object value, object expected, LayoutRenderer appSettingLayoutRenderer)
+        {
             Session[key] = value;
 
             var rendered = appSettingLayoutRenderer.Render(LogEventInfo.CreateNullEvent());

--- a/NLog.Web.Tests/LayoutRenderers/AspNetSessionValueLayoutRendererTests.cs
+++ b/NLog.Web.Tests/LayoutRenderers/AspNetSessionValueLayoutRendererTests.cs
@@ -18,7 +18,7 @@ namespace NLog.Web.Tests.LayoutRenderers
         [TestCleanup]
         public void CleanUp()
         {
-        
+
             Session.Clear();
         }
 
@@ -64,7 +64,7 @@ namespace NLog.Web.Tests.LayoutRenderers
                 EvaluateAsNestedProperties = true
             };
 
-            var o = new {b = "c"};
+            var o = new { b = "c" };
             //set in "a"
             ExecTest("a", o, "c", appSettingLayoutRenderer);
         }
@@ -170,9 +170,9 @@ namespace NLog.Web.Tests.LayoutRenderers
         {
             Layout layout = "${aspnet-session:a.b:culture=en-GB:evaluateAsNestedProperties=true}";
 
-            var o = new { b = new DateTime(2015,11,24) };
+            var o = new { b = new DateTime(2015, 11, 24, 2, 30, 23) };
             //set in "a"
-            ExecTest("a", o, "    c", layout);
+            ExecTest("a", o, "11/24/2015 2:30:23 AM", layout);
         }
 
         /// <summary>
@@ -231,7 +231,7 @@ namespace NLog.Web.Tests.LayoutRenderers
                                         null)
                                 .Invoke(new object[] { sessionContainer });
 
-           HttpContext.Current = httpContext;
+            HttpContext.Current = httpContext;
 
         }
     }

--- a/NLog.Web/LayoutRenderers/AspNetApplicationValueLayoutRenderer.cs
+++ b/NLog.Web/LayoutRenderers/AspNetApplicationValueLayoutRenderer.cs
@@ -67,7 +67,7 @@ namespace NLog.Web.LayoutRenderers
                 return;
             }
 
-            builder.Append(Convert.ToString(context.Application[this.Variable], CultureInfo.InvariantCulture));
+            builder.Append(Convert.ToString(context.Application[this.Variable], CultureInfo.CurrentUICulture));
         }
     }
 }

--- a/NLog.Web/LayoutRenderers/AspNetItemValueLayoutRenderer.cs
+++ b/NLog.Web/LayoutRenderers/AspNetItemValueLayoutRenderer.cs
@@ -71,7 +71,7 @@ namespace NLog.Web.LayoutRenderers
 
             var value = PropertyReader.GetValue(Variable, k => context.Items[k], EvaluateAsNestedProperties);
 
-            builder.Append(Convert.ToString(value, CultureInfo.InvariantCulture));
+            builder.Append(Convert.ToString(value, CultureInfo.CurrentUICulture));
         }
     }
 }

--- a/NLog.Web/LayoutRenderers/AspNetRequestValueLayoutRenderer.cs
+++ b/NLog.Web/LayoutRenderers/AspNetRequestValueLayoutRenderer.cs
@@ -69,22 +69,23 @@ namespace NLog.Web.LayoutRenderers
                 return;
             }
 
-            if (context.Request == null)
+            var httpRequest = context.Request;
+            if (httpRequest == null)
             {
                 return;
             }
 
             if (this.QueryString != null)
             {
-                builder.Append(context.Request.QueryString[this.QueryString]);
+                builder.Append(httpRequest.QueryString[this.QueryString]);
             }
             else if (this.Form != null)
             {
-                builder.Append(context.Request.Form[this.Form]);
+                builder.Append(httpRequest.Form[this.Form]);
             }
             else if (this.Cookie != null)
             {
-                HttpCookie cookie = context.Request.Cookies[this.Cookie];
+                HttpCookie cookie = httpRequest.Cookies[this.Cookie];
 
                 if (cookie != null)
                 {
@@ -93,11 +94,11 @@ namespace NLog.Web.LayoutRenderers
             }
             else if (this.ServerVariable != null)
             {
-                builder.Append(context.Request.ServerVariables[this.ServerVariable]);
+                builder.Append(httpRequest.ServerVariables[this.ServerVariable]);
             }
             else if (this.Item != null)
             {
-                builder.Append(context.Request[this.Item]);
+                builder.Append(httpRequest[this.Item]);
             }
         }
     }

--- a/NLog.Web/LayoutRenderers/AspNetSessionValueLayoutRenderer.cs
+++ b/NLog.Web/LayoutRenderers/AspNetSessionValueLayoutRenderer.cs
@@ -76,7 +76,7 @@ namespace NLog.Web.LayoutRenderers
             }
             var value = PropertyReader.GetValue(Variable, k => context.Session[k], EvaluateAsNestedProperties);
 
-            builder.Append(Convert.ToString(value, CultureInfo.InvariantCulture));
+            builder.Append(Convert.ToString(value, CultureInfo.CurrentUICulture));
         }
     }
 }


### PR DESCRIPTION
This wan't working:

```
${aspnet-session:variable=anothervariable:culture=pl-PL} 
```

because `InvariantCulture` was used. Now using UICulture.

Supported in:

* ${aspnet-application}
* ${aspnet-request}
* ${aspnet-session}
* ${aspnet-item}

