### PR TITLE
DNX: Prevent stackoverflowException in ${aspnet-session}

### DIFF
--- a/NLog.Web.ASPNET5/LayoutRenderers/AspNetSessionValueLayoutRenderer.cs
+++ b/NLog.Web.ASPNET5/LayoutRenderers/AspNetSessionValueLayoutRenderer.cs
@@ -7,6 +7,7 @@ using NLog.Common;
 #if !DNX
 using System.Web;
 #else
+using Microsoft.AspNet.Http.Features;
 using Microsoft.AspNet.Http;
 #endif
 using NLog.Config;
@@ -83,6 +84,11 @@ namespace NLog.Web.LayoutRenderers
                 return;
             }
 
+            if (context.Features.Get<ISessionFeature>()?.Session == null)
+            {
+                return;
+            }
+
             //because session.get / session.getstring also creating log messages in some cases, this could lead to stackoverflow issues. 
             //We remember on the context.Items that we are looking up a session value so we prevent stackoverflows
             if (context.Items.ContainsKey(NLogRetrievingSessionValue))
@@ -90,7 +96,7 @@ namespace NLog.Web.LayoutRenderers
                 //prevent stackoverflow
                 return;
             }
-
+            
             context.Items[NLogRetrievingSessionValue] = true;
             object value;
             try

--- a/NLog.Web.ASPNET5/LayoutRenderers/AspNetSessionValueLayoutRenderer.cs
+++ b/NLog.Web.ASPNET5/LayoutRenderers/AspNetSessionValueLayoutRenderer.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading;
+using NLog.Common;
 #if !DNX
 using System.Web;
 #else
@@ -95,6 +96,12 @@ namespace NLog.Web.LayoutRenderers
             try
             {
                 value = PropertyReader.GetValue(Variable, k => context.Session.GetString(k), EvaluateAsNestedProperties);
+            }
+            catch (Exception ex)
+            {
+                //TODO change this call for NLog 4.3
+                InternalLogger.Warn("Retrieving session value failed. "  + ex);
+                return;
             }
             finally
             {


### PR DESCRIPTION
Prevent stackoverflowException in `${aspnet-session}` by using `HttpContext.Items`.

In case of an session issue, [ASP.NET session will log a warning](https://github.com/aspnet/Session/blob/1.0.0-rc1/src/Microsoft.AspNet.Session/DistributedSession.cs#L142). This could lead to a `StackOverflowException `.

We will prevent this by pushing and removing an item on `context.Items `

Details in https://github.com/NLog/NLog.Extensions.Logging/issues/28

Fixes https://github.com/NLog/NLog.Extensions.Logging/issues/28, fixes https://github.com/NLog/NLog.Web/issues/43

needs confirmation. 