### PR TITLE
Suppressing exception thrown when accessing HttpContext.Request

### DIFF
--- a/NLog.Web.ASPNET5.Tests/LayoutRenderers/AspNetRequestValueLayoutRendererTests.cs
+++ b/NLog.Web.ASPNET5.Tests/LayoutRenderers/AspNetRequestValueLayoutRendererTests.cs
@@ -1,7 +1,11 @@
 ﻿using System.Collections.Specialized;
+using System.IO;
 using System.Web;
+using NLog.Common;
+using NLog.Config;
 using NLog.Web.LayoutRenderers;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace NLog.Web.Tests.LayoutRenderers
@@ -16,6 +20,25 @@ namespace NLog.Web.Tests.LayoutRenderers
             string result = renderer.Render(new LogEventInfo());
 
             Assert.Empty(result);
+        }
+
+        [Fact]
+        public void NullRequestRendersEmptyStringWithoutThrowingException()
+        {
+            var internalLog = new StringWriter();
+            InternalLogger.LogWriter = internalLog;
+
+            var httpContext = Substitute.For<HttpContextBase>();
+            httpContext.Request.Returns(x => { throw new HttpException(); });
+
+            var renderer = new AspNetRequestValueLayoutRenderer();
+            renderer.HttpContextAccessor = new FakeHttpContextAccessor(httpContext);
+            renderer.Item = "key";
+
+            string result = renderer.Render(new LogEventInfo());
+
+            Assert.Empty(result);
+            Assert.Equal(true, string.IsNullOrEmpty(internalLog.ToString()));
         }
 
         public class ItemTests

--- a/NLog.Web.ASPNET5.Tests/LayoutRenderers/AspNetRequestValueLayoutRendererTests.cs
+++ b/NLog.Web.ASPNET5.Tests/LayoutRenderers/AspNetRequestValueLayoutRendererTests.cs
@@ -23,10 +23,11 @@ namespace NLog.Web.Tests.LayoutRenderers
         }
 
         [Fact]
-        public void NullRequestRendersEmptyStringWithoutThrowingException()
+        public void NullRequestRendersEmptyStringWithoutLoggingError()
         {
             var internalLog = new StringWriter();
             InternalLogger.LogWriter = internalLog;
+            InternalLogger.LogLevel = LogLevel.Error;
 
             var httpContext = Substitute.For<HttpContextBase>();
             httpContext.Request.Returns(x => { throw new HttpException(); });

--- a/NLog.Web.ASPNET5/LayoutRenderers/AspNetRequestValueLayoutRenderer.cs
+++ b/NLog.Web.ASPNET5/LayoutRenderers/AspNetRequestValueLayoutRenderer.cs
@@ -76,7 +76,7 @@ namespace NLog.Web.LayoutRenderers
         /// <param name="logEvent">Logging event.</param>
         protected override void DoAppend(StringBuilder builder, LogEventInfo logEvent)
         {
-            var httpRequest = HttpContextAccessor.HttpContext.Request;
+            var httpRequest = HttpContextAccessor.HttpContext.TryGetRequest();
             if (httpRequest == null)
             {
                 return;
@@ -134,6 +134,21 @@ namespace NLog.Web.LayoutRenderers
 #else
                 builder.Append(httpRequest.HttpContext.Items[this.Item]);
 #endif
+            }
+        }
+    }
+
+    internal static class RequestAccessor
+    {
+        internal static HttpRequestBase TryGetRequest(this HttpContextBase context)
+        {
+            try
+            {
+                return context.Request;
+            }
+            catch (HttpException)
+            {
+                return null;
             }
         }
     }

--- a/NLog.Web.ASPNET5/LayoutRenderers/AspNetRequestValueLayoutRenderer.cs
+++ b/NLog.Web.ASPNET5/LayoutRenderers/AspNetRequestValueLayoutRenderer.cs
@@ -141,6 +141,7 @@ namespace NLog.Web.LayoutRenderers
 
     internal static class RequestAccessor
     {
+#if !DNX
         internal static HttpRequestBase TryGetRequest(this HttpContextBase context)
         {
             try
@@ -153,5 +154,12 @@ namespace NLog.Web.LayoutRenderers
                 return null;
             }
         }
+#else
+        internal static HttpRequest TryGetRequest(this HttpContext context)
+        {
+            return context.Request;
+        }
+#endif
     }
+
 }

--- a/NLog.Web.ASPNET5/LayoutRenderers/AspNetRequestValueLayoutRenderer.cs
+++ b/NLog.Web.ASPNET5/LayoutRenderers/AspNetRequestValueLayoutRenderer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using NLog.Common;
 #if !DNX
 using System.Web;
 #else
@@ -146,8 +147,9 @@ namespace NLog.Web.LayoutRenderers
             {
                 return context.Request;
             }
-            catch (HttpException)
+            catch (HttpException ex)
             {
+                InternalLogger.Debug("Exception thrown when accessing Request: " + ex);
                 return null;
             }
         }


### PR DESCRIPTION
As a response to https://github.com/NLog/NLog.Web/issues/31

I have *not* kept the old behavior for .net core.