### PR TITLE
iis-site-name should return app name in ASP.NET Core

### DIFF
--- a/NLog.Web.AspNetCore/LayoutRenderers/IISInstanceNameLayoutRenderer.cs
+++ b/NLog.Web.AspNetCore/LayoutRenderers/IISInstanceNameLayoutRenderer.cs
@@ -36,7 +36,7 @@ namespace NLog.Web.LayoutRenderers
 
 #if NETSTANDARD_1plus
             var env = ServiceLocator.ServiceProvider?.GetService<IHostingEnvironment>();
-            builder.Append(env?.EnvironmentName);
+            builder.Append(env?.ApplicationName);
 
 #else
             builder.Append(HostingEnvironment.SiteName);


### PR DESCRIPTION
For ASP.NET Core:

`IHostingEnvironment.EnvironmentName` = "Development", "Production", "Staging", etc.
`IHostingEnvironment.ApplicationName` = the app name

The layout renderer for "iis-site-name" is incorrectly rendering the first instead of the second.