### PR TITLE
Update vulnerable dependency

### DIFF
--- a/NLog.Web.AspNetCore/NLog.Web.AspNetCore.csproj
+++ b/NLog.Web.AspNetCore/NLog.Web.AspNetCore.csproj
@@ -36,12 +36,14 @@
     <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="1.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="1.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="1.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="1.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="1.0.4" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.0.0" />
     
     <PackageReference Include="NLog" Version="5.0.0-beta05" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.0.0-rtm-beta3" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
+    <DotNetCliToolReference Include="dotnet-retire" Version="1.0.4" />
+
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">

--- a/NLog.Web.AspNetCore/NLog.Web.AspNetCore.csproj
+++ b/NLog.Web.AspNetCore/NLog.Web.AspNetCore.csproj
@@ -42,7 +42,6 @@
     <PackageReference Include="NLog" Version="5.0.0-beta05" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.0.0-rtm-beta3" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
-
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">

--- a/NLog.Web.AspNetCore/NLog.Web.AspNetCore.csproj
+++ b/NLog.Web.AspNetCore/NLog.Web.AspNetCore.csproj
@@ -42,7 +42,6 @@
     <PackageReference Include="NLog" Version="5.0.0-beta05" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.0.0-rtm-beta3" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
-    <DotNetCliToolReference Include="dotnet-retire" Version="1.0.4" />
 
   </ItemGroup>
 


### PR DESCRIPTION
Hi,

I scanned Nlog.Web.AspNetCore using [dotnet retire](https://github.com/RetireNet/dotnet-retire) and found use of a vulnerable dependency. This PR bumps the package that brings this dependency in.

![image](https://user-images.githubusercontent.com/206726/26969550-6bb4cace-4d06-11e7-96aa-2ae41699721c.png)


Dependency chain resulting in use [of vulnerable dependency `System.Text.Encodings.Web/4.0.0`](https://github.com/dotnet/announcements/issues/12) :

[Microsoft.AspNetCore.Routing.Abstractions/1.0.3](https://www.nuget.org/packages/Microsoft.AspNetCore.Routing.Abstractions/1.0.3)
=> 
[Microsoft.AspNetCore.Http.Abstractions/1.0.2](https://www.nuget.org/packages/Microsoft.AspNetCore.Http.Abstractions/1.0.2)
=>
[System.Text.Encodings.Web/4.0.0](https://www.nuget.org/packages/System.Text.Encodings.Web/4.0.0)
