### PR TITLE
Run test for asp.net core on full and core framework, fix unit test build

### DIFF
--- a/NLog.Web.AspNetCore.Tests/NLog.Web.AspNetCore.Tests.csproj
+++ b/NLog.Web.AspNetCore.Tests/NLog.Web.AspNetCore.Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="1.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="1.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="1.1.1" />
-    <PackageReference Include="NLog" Version="5.0.0-beta06" />
+    <PackageReference Include="NLog" Version="5.0.0-beta07" />
     <PackageReference Include="NSubstitute" Version="2.0.2" />
     <PackageReference Include="xunit" Version="2.3.0-beta1-build3642" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta1-build3642" />

--- a/NLog.Web.AspNetCore.Tests/NLog.Web.AspNetCore.Tests.csproj
+++ b/NLog.Web.AspNetCore.Tests/NLog.Web.AspNetCore.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp1.0</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp1.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);NETSTANDARD_1plus</DefineConstants>
     <AssemblyName>NLog.Web.AspNetCore.Tests</AssemblyName>
     <AssemblyVersion>1.2.3.0</AssemblyVersion>
@@ -12,16 +12,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="1.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="1.1.1" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta1-build1309" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-*" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="1.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="1.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="1.1.1" />
     <PackageReference Include="NLog" Version="5.0.0-beta07" />
     <PackageReference Include="NSubstitute" Version="2.0.2" />
-    <PackageReference Include="xunit" Version="2.3.0-beta1-build3642" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta1-build3642" />
+    <PackageReference Include="xunit" Version="2.3.0-beta3-*" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta3-*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NLog.Web.AspNetCore.Tests/NLog.Web.AspNetCore.Tests.csproj
+++ b/NLog.Web.AspNetCore.Tests/NLog.Web.AspNetCore.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp1.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);NETSTANDARD_1plus</DefineConstants>
     <AssemblyName>NLog.Web.AspNetCore.Tests</AssemblyName>
     <AssemblyVersion>1.2.3.0</AssemblyVersion>
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="1.1.0" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta1-build1309" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="1.1.1" />

--- a/NLog.Web.AspNetCore.Tests/NLog.Web.AspNetCore.Tests.csproj
+++ b/NLog.Web.AspNetCore.Tests/NLog.Web.AspNetCore.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp1.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp1.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);NETSTANDARD_1plus</DefineConstants>
     <AssemblyName>NLog.Web.AspNetCore.Tests</AssemblyName>
     <AssemblyVersion>1.2.3.0</AssemblyVersion>

--- a/NLog.Web.AspNetCore/NLog.Web.AspNetCore.csproj
+++ b/NLog.Web.AspNetCore/NLog.Web.AspNetCore.csproj
@@ -34,7 +34,6 @@
   <ItemGroup>
     
     <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="1.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="1.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="1.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="1.0.4" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.0.0" />

--- a/NLog.Web.AspNetCore/NLog.Web.AspNetCore.csproj
+++ b/NLog.Web.AspNetCore/NLog.Web.AspNetCore.csproj
@@ -34,6 +34,7 @@
   <ItemGroup>
     
     <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="1.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="1.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="1.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="1.0.4" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.0.0" />

--- a/NLog.Web.AspNetCore/NLog.Web.AspNetCore.csproj
+++ b/NLog.Web.AspNetCore/NLog.Web.AspNetCore.csproj
@@ -33,10 +33,9 @@
 
   <ItemGroup>
     
-    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="1.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="1.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="1.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="1.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="1.1.1" />    
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="1.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.0.0" />
     
     <PackageReference Include="NLog" Version="5.0.0-beta07" />

--- a/test_aspnetcore.bat
+++ b/test_aspnetcore.bat
@@ -4,5 +4,5 @@ rem update project.json for version number
 cd NLog.Web.AspNetCore.Tests 
 call dotnet restore 
 call dotnet build  --configuration release 
-call dotnet xunit  
+call dotnet xunit -framework netcoreapp1.0
 cd ..

--- a/test_aspnetcore.bat
+++ b/test_aspnetcore.bat
@@ -4,5 +4,5 @@ rem update project.json for version number
 cd NLog.Web.AspNetCore.Tests 
 call dotnet restore 
 call dotnet build  --configuration release 
-call dotnet xunit -framework netcoreapp1.0
+call dotnet xunit
 cd ..


### PR DESCRIPTION
I think this fixes #151 without breaking it, but I could not run the tests on the machine I'm currently on because they're only target full framework.