### PR TITLE
Add IncludeScheme option to ${aspnet-request-url}

### DIFF
--- a/NLog.Web.AspNetCore.Tests/LayoutRenderers/AspNetRequestUrlRendererTests.cs
+++ b/NLog.Web.AspNetCore.Tests/LayoutRenderers/AspNetRequestUrlRendererTests.cs
@@ -33,7 +33,7 @@ namespace NLog.Web.Tests.LayoutRenderers
         }
 
         [Fact]
-        public void UrlPresentRenderNonEmpty_ExcludeQueryString()
+        public void UrlPresentRenderNonEmpty_Default()
         {
             var renderer = CreateRenderer("www.google.com:80", "?t=1", "http");
 
@@ -57,22 +57,18 @@ namespace NLog.Web.Tests.LayoutRenderers
         [Fact]
         public void UrlPresentRenderNonEmpty_IncludeQueryString_IncludePort()
         {
-            var expected = "http://www.google.com:80/Test.asp?t=1";
-
             var renderer = CreateRenderer("www.google.com:80", "?t=1", "http", "/Test.asp");
             renderer.IncludeQueryString = true;
             renderer.IncludePort = true;
 
             string result = renderer.Render(LogEventInfo.CreateNullEvent());
 
-            Assert.Equal(expected, result);
+            Assert.Equal("http://www.google.com:80/Test.asp?t=1", result);
         }
 
         [Fact]
         public void UrlPresentRenderNonEmpty_IncludeQueryString_ExcludePort()
         {
-            var expected = "http://www.google.com/Test.asp?t=1";
-
             var renderer = CreateRenderer("www.google.com:80", "?t=1", "http", "/Test.asp");
 
             renderer.IncludeQueryString = true;
@@ -80,19 +76,88 @@ namespace NLog.Web.Tests.LayoutRenderers
 
             string result = renderer.Render(LogEventInfo.CreateNullEvent());
 
-            Assert.Equal(expected, result);
+            Assert.Equal("http://www.google.com/Test.asp?t=1", result);
         }
 
         [Fact]
         public void UrlPresentRenderNonEmpty_ExcludeQueryString_ExcludePort()
         {
-            var expected = "http://www.google.com/Test.asp";
-
             var renderer = CreateRenderer("www.google.com:80", "?t=1", "http", "/Test.asp");
 
             string result = renderer.Render(LogEventInfo.CreateNullEvent());
 
-            Assert.Equal(expected, result);
+            Assert.Equal("http://www.google.com/Test.asp", result);
+        }
+
+        [Fact]
+        public void UrlPresentRenderNonEmpty_ExcludeScheme()
+        {
+            var renderer = CreateRenderer("www.google.com:80", "?t=1", "http", "/Test.asp");
+            renderer.IncludeScheme = false;
+
+            string result = renderer.Render(LogEventInfo.CreateNullEvent());
+
+            Assert.Equal("www.google.com/Test.asp", result);
+        }
+
+        [Fact]
+        public void UrlPresentRenderNonEmpty_ExcludeScheme_IncludePort_IncludeQueryString()
+        {
+            var renderer = CreateRenderer("www.google.com:80", "?t=1", "http", "/Test.asp");
+            renderer.IncludeScheme = false;
+            renderer.IncludePort = true;
+            renderer.IncludeQueryString = true;
+
+            string result = renderer.Render(LogEventInfo.CreateNullEvent());
+
+            Assert.Equal("www.google.com:80/Test.asp?t=1", result);
+        }
+
+        [Fact]
+        public void UrlPresentRenderNonEmpty_ExcludeScheme_IncludePort()
+        {
+            var renderer = CreateRenderer("www.google.com:80", "?t=1", "http", "/Test.asp");
+            renderer.IncludeScheme = false;
+            renderer.IncludePort = true;
+
+            string result = renderer.Render(LogEventInfo.CreateNullEvent());
+
+            Assert.Equal("www.google.com:80/Test.asp", result);
+        }
+
+        [Fact]
+        public void UrlPresentRenderNonEmpty_ExcludeScheme_ExcludeHost()
+        {
+            var renderer = CreateRenderer("www.google.com:80", "?t=1", "http", "/Test.asp");
+            renderer.IncludeScheme = false;
+            renderer.IncludeHost = false;
+
+            string result = renderer.Render(LogEventInfo.CreateNullEvent());
+
+            Assert.Equal("/Test.asp", result);
+        }
+
+        [Fact]
+        public void UrlPresentRenderNonEmpty_ExcludeHost()
+        {
+            var renderer = CreateRenderer("www.google.com:80", "?t=1", "http", "/Test.asp");
+            renderer.IncludeHost = false;
+
+            string result = renderer.Render(LogEventInfo.CreateNullEvent());
+
+            Assert.Equal("http:///Test.asp", result);
+        }
+
+        [Fact]
+        public void UrlPresentRenderNonEmpty_ExcludeHost_IncludeQueryString()
+        {
+            var renderer = CreateRenderer("www.google.com:80", "?t=1", "http", "/Test.asp");
+            renderer.IncludeHost = false;
+            renderer.IncludeQueryString = true;
+
+            string result = renderer.Render(LogEventInfo.CreateNullEvent());
+
+            Assert.Equal("http:///Test.asp?t=1", result);
         }
 
         private static AspNetRequestUrlRenderer CreateRenderer(string hostBase, string queryString = "", string scheme = "http", string page = "/", string pathBase = "")

--- a/NLog.Web.AspNetCore/LayoutRenderers/AspNetRequestUrlRenderer.cs
+++ b/NLog.Web.AspNetCore/LayoutRenderers/AspNetRequestUrlRenderer.cs
@@ -22,6 +22,7 @@ namespace NLog.Web.LayoutRenderers
     /// ${aspnet-request-url:IncludeQueryString=false} - produces http://www.exmaple.com/
     /// ${aspnet-request-url:IncludePort=true} - produces http://www.exmaple.com:80/
     /// ${aspnet-request-url:IncludePort=false} - produces http://www.exmaple.com/
+    /// ${aspnet-request-url:IncludeScheme=false} - produces www.exmaple.com/
     /// ${aspnet-request-url:IncludePort=true:IncludeQueryString=true} - produces http://www.exmaple.com:80/?t=1    
     /// </code>
     /// </example>
@@ -42,6 +43,12 @@ namespace NLog.Web.LayoutRenderers
         /// To specify whether to exclude / include the host. Default is true.
         /// </summary>
         public bool IncludeHost { get; set; } = true;
+
+
+        /// <summary>
+        /// To specify whether to exclude / include the scheme. Default is true.
+        /// </summary>
+        public bool IncludeScheme { get; set; } = true;
 
         /// <summary>
         /// Renders the Request URL from the HttpRequest
@@ -84,11 +91,12 @@ namespace NLog.Web.LayoutRenderers
                 host = httpRequest.Url?.Host;
             }
 
-            scheme = httpRequest.Url.Scheme;
+            if (IncludeScheme)
+            {
+                scheme = httpRequest.Url.Scheme + "://";
+            }
 
-            url = $"{scheme}://{host}{port}{pathAndQuery}";
-
-
+            url = $"{scheme}{host}{port}{pathAndQuery}";
 #else
             if (IncludeQueryString)
             {
@@ -105,16 +113,14 @@ namespace NLog.Web.LayoutRenderers
                 host = httpRequest.Host.Host;
             }
 
-            if (!String.IsNullOrEmpty(httpRequest.Scheme))
+            if (IncludeScheme && !String.IsNullOrWhiteSpace(httpRequest.Scheme))
+            { 
                 scheme = httpRequest.Scheme + "://";
+            }
 
             url = $"{scheme}{host}{port}{httpRequest.PathBase.ToUriComponent()}{httpRequest.Path.ToUriComponent()}{pathAndQuery}";
-
-
-
 #endif
             builder.Append(url);
-
         }
     }
 }


### PR DESCRIPTION
Currently the AspNetRequestUrlRenderer doesn't let you do relative urls
e.g. /somepath?q=stuff

If you set *IncludeHost=false* you end up with the scheme (http://) included
http:///somepath?q=stuff

I've added an IncludeScheme option so that the "http://" part can be excluded too.