### PR TITLE
Register HttpContextAccessor by default

### DIFF
--- a/NLog.Web.AspNetCore.Tests/AspNetCoreTests.cs
+++ b/NLog.Web.AspNetCore.Tests/AspNetCoreTests.cs
@@ -9,6 +9,7 @@ using Castle.Core.Logging;
 using Xunit;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NLog.Config;
@@ -33,14 +34,7 @@ namespace NLog.Web.AspNetCore.Tests
         [Fact]
         public void UseNLogShouldLogTest()
         {
-            var webhost =
-                Microsoft.AspNetCore.WebHost.CreateDefaultBuilder()
-                .Configure(c => c.New()) //.New needed, otherwise:
-                                         // Unhandled Exception: System.ArgumentException: A valid non-empty application name must be provided.
-                                         // Parameter name: applicationName
-                    .UseNLog() //use NLog for ILoggers and pass httpcontext
-                    .Build();
-
+            var webhost = CreateWebHost();
 
             var loggerFact = webhost.Services.GetService<Microsoft.Extensions.Logging.ILoggerFactory>();
 
@@ -64,6 +58,42 @@ namespace NLog.Web.AspNetCore.Tests
             Assert.Equal("logger1|error1", logged.First());
 
 
+
+
+
+        }
+
+
+
+        [Fact]
+        public void RegisterHttpContext()
+        {
+            var webhost = CreateWebHost();
+            Assert.NotNull(webhost.Services.GetService<IHttpContextAccessor>());
+
+        }
+        [Fact]
+        public void SkipRegisterHttpContext()
+        {
+            var webhost = CreateWebHost(new NLogAspNetCoreOptions { RegisterHttpContextAccessor = false });
+            Assert.Null(webhost.Services.GetService<IHttpContextAccessor>());
+
+        }
+
+        /// <summary>
+        /// Create webhost with UseNlog
+        /// </summary>
+        /// <returns></returns>
+        private static IWebHost CreateWebHost(NLogAspNetCoreOptions options = null)
+        {
+            var webhost =
+                Microsoft.AspNetCore.WebHost.CreateDefaultBuilder()
+                    .Configure(c => c.New()) //.New needed, otherwise:
+                                             // Unhandled Exception: System.ArgumentException: A valid non-empty application name must be provided.
+                                             // Parameter name: applicationName
+                    .UseNLog(options) //use NLog for ILoggers and pass httpcontext
+                    .Build();
+            return webhost;
         }
 
     }

--- a/NLog.Web.AspNetCore/Internal/ServiceLocator.cs
+++ b/NLog.Web.AspNetCore/Internal/ServiceLocator.cs
@@ -18,9 +18,6 @@ namespace NLog.Web.Internal
         /// </summary>
         public static IServiceProvider ServiceProvider { get; set; }
 
-        /// <summary>
-        /// Registering needed services
-        /// </summary>
-        public static IServiceCollection Services { get; set; }
+   
     }
 }

--- a/NLog.Web.AspNetCore/LayoutRenderers/AspNetLayoutRendererBase.cs
+++ b/NLog.Web.AspNetCore/LayoutRenderers/AspNetLayoutRendererBase.cs
@@ -2,11 +2,13 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+
 using NLog.LayoutRenderers;
 #if ASP_NET_CORE
 using NLog.Web.Internal;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 #endif
 
 namespace NLog.Web.LayoutRenderers
@@ -46,7 +48,13 @@ namespace NLog.Web.LayoutRenderers
 
         private static IHttpContextAccessor RetrieveHttpContextAccessor()
         {
-            var httpContextAccessor = ServiceLocator.ServiceProvider?.GetService<IHttpContextAccessor>();
+            var serviceProvider = ServiceLocator.ServiceProvider;
+            if (serviceProvider == null)
+            {
+                Common.InternalLogger.Debug("Missing serviceProvider, so no HttpContext");
+            }
+
+            var httpContextAccessor = serviceProvider.GetService<IHttpContextAccessor>();
             if (httpContextAccessor == null)
             {
                 Common.InternalLogger.Debug("Missing IHttpContextAccessor, so no HttpContext");
@@ -86,7 +94,7 @@ namespace NLog.Web.LayoutRenderers
 
 #if ASP_NET_CORE
 
-/// <inheritdoc />
+        /// <inheritdoc />
         protected override void CloseLayoutRenderer()
         {
             _httpContextAccessor = null;

--- a/NLog.Web.AspNetCore/LayoutRenderers/AspNetSessionValueLayoutRenderer.cs
+++ b/NLog.Web.AspNetCore/LayoutRenderers/AspNetSessionValueLayoutRenderer.cs
@@ -86,6 +86,7 @@ namespace NLog.Web.LayoutRenderers
             var context = HttpContextAccessor.HttpContext;
             if (context?.Session == null)
             {
+                InternalLogger.Debug("Session is null");
                 return;
             }
 #if !ASP_NET_CORE

--- a/NLog.Web.AspNetCore/NLog.Web.AspNetCore.csproj
+++ b/NLog.Web.AspNetCore/NLog.Web.AspNetCore.csproj
@@ -44,16 +44,21 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="1.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="1.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="1.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="2.0.0" />
     
+  </ItemGroup>
+  <ItemGroup>
+   
   </ItemGroup>
 
 

--- a/NLog.Web.AspNetCore/NLogAspNetCoreOptions.cs
+++ b/NLog.Web.AspNetCore/NLogAspNetCoreOptions.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+using NLog.Extensions.Logging;
+
+namespace NLog.Web.AspNetCore
+{
+    /// <summary>
+    /// Options for ASP.NET Core and NLog
+    /// </summary>
+    public sealed class NLogAspNetCoreOptions : NLogProviderOptions
+    {
+        /// <summary>
+        /// Register the HttpContextAccessor when not yet registed. Default <c>true</c>
+        /// </summary>
+        /// <remarks>needed for various layout renderers</remarks>
+        [DefaultValue(true)]
+        public bool RegisterHttpContextAccessor { get; set; } = true;
+
+        /// <summary>
+        /// The default options
+        /// </summary>
+        public static NLogAspNetCoreOptions Default { get; } = new NLogAspNetCoreOptions();
+    }
+}

--- a/NLog.Web.AspNetCore/Properties/AssemblyInfo.cs
+++ b/NLog.Web.AspNetCore/Properties/AssemblyInfo.cs
@@ -24,3 +24,4 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("74d5915b-bea9-404c-b4d0-b663164def37")]
+[assembly:InternalsVisibleTo("NLog.Web.AspNetCore.Tests,PublicKey=0024000004800000940000000602000000240000525341310004000001000100ef8eab4fbdeb511eeb475e1659fe53f00ec1c1340700f1aa347bf3438455d71993b28b1efbed44c8d97a989e0cb6f01bcb5e78f0b055d311546f63de0a969e04cf04450f43834db9f909e566545a67e42822036860075a1576e90e1c43d43e023a24c22a427f85592ae56cac26f13b7ec2625cbc01f9490d60f16cfbb1bc34d9")]


### PR DESCRIPTION
Register HttpContextAccessor by default, added NLogAspNetCoreOptions

fixes #73 