### PR TITLE
Auto register NLog.Web.AspNetCore (ASP.NET 2 only)

### DIFF
--- a/NLog.Web.AspNetCore.Tests/AspNetCoreTests.cs
+++ b/NLog.Web.AspNetCore.Tests/AspNetCoreTests.cs
@@ -13,8 +13,10 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NLog.Config;
+using NLog.Layouts;
 using NLog.Targets;
 using NLog.Web.Tests.LayoutRenderers;
+using ILoggerFactory = Microsoft.Extensions.Logging.ILoggerFactory;
 
 
 namespace NLog.Web.AspNetCore.Tests
@@ -36,15 +38,11 @@ namespace NLog.Web.AspNetCore.Tests
         {
             var webhost = CreateWebHost();
 
-            var loggerFact = webhost.Services.GetService<Microsoft.Extensions.Logging.ILoggerFactory>();
+            var loggerFact = GetLoggerFactory(webhost);
 
             Assert.NotNull(loggerFact);
 
-            var configuration = new LoggingConfiguration();
-            var target = new MemoryTarget("target1");
-            target.Layout = "${logger}|${message}";
-
-            configuration.AddRuleForAllLevels(target);
+            var configuration = CreateConfigWithMemoryTarget(out var target, "${logger}|${message}");
 
             LogManager.Configuration = configuration;
 
@@ -57,11 +55,57 @@ namespace NLog.Web.AspNetCore.Tests
             Assert.Single(logged);
             Assert.Equal("logger1|error1", logged.First());
 
+        }
+
+        private static LoggingConfiguration CreateConfigWithMemoryTarget(out MemoryTarget target, Layout layout)
+        {
+            var configuration = new LoggingConfiguration();
+            target = new MemoryTarget("target1") { Layout = layout };
+
+            configuration.AddRuleForAllLevels(target);
+            return configuration;
+        }
 
 
+        [Fact]
+        public void UseAspNetWithoutRegister()
+        {
+            try
+            {
 
+
+                //clear everything besides NLog
+                ConfigurationItemFactory.Default.Clear();
+                ConfigurationItemFactory.Default.RegisterItemsFromAssembly(typeof(Logger).Assembly);
+
+                var webhost = CreateWebHost();
+
+                var configuration = CreateConfigWithMemoryTarget(out var target, "${logger}|${message}|${aspnet-item:key1}");
+
+                LogManager.Configuration = configuration;
+
+                var httpContext = webhost.Services.GetService<IHttpContextAccessor>().HttpContext = new DefaultHttpContext();
+                httpContext.Items["key1"] = "value1";
+
+                var loggerFact = GetLoggerFactory(webhost);
+
+                var logger = loggerFact.CreateLogger("logger1");
+
+                logger.LogError("error1");
+
+                var logged = target.Logs;
+
+                Assert.Single(logged);
+                Assert.Equal("logger1|error1|value1", logged.First());
+            }
+            finally
+            {
+                //clear so next time it's rebuild
+                ConfigurationItemFactory.Default = null;
+            }
 
         }
+
 
 
 
@@ -94,6 +138,11 @@ namespace NLog.Web.AspNetCore.Tests
                     .UseNLog(options) //use NLog for ILoggers and pass httpcontext
                     .Build();
             return webhost;
+        }
+
+        private static ILoggerFactory GetLoggerFactory(IWebHost webhost)
+        {
+            return webhost.Services.GetService<Microsoft.Extensions.Logging.ILoggerFactory>();
         }
 
     }

--- a/NLog.Web.AspNetCore/AspNetExtensions.cs
+++ b/NLog.Web.AspNetCore/AspNetExtensions.cs
@@ -87,12 +87,19 @@ namespace NLog.Web
                 services.AddSingleton<ILoggerFactory>(serviceProvider =>
                 {
                     ServiceLocator.ServiceProvider = serviceProvider;
+
+                    //register yourself
+                    ConfigurationItemFactory.Default.RegisterItemsFromAssembly(typeof(AspNetExtensions).Assembly);
+
                     return new NLogLoggerFactory(options);
                 });
                 if (options.RegisterHttpContextAccessor)
                 {
                     services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
                 }
+
+
+
             });
             return builder;
         }


### PR DESCRIPTION
No need for 

```xml
<extensions>
    <add assembly="NLog.Web.AspNetCore"/>
  </extensions>

```

any more.

usage of `.UseNLog()` required

fixes https://github.com/NLog/NLog.Web/issues/187

