### PR TITLE
Automatically register NLog.Web LayoutRenders for NetCoreApp1

### DIFF
--- a/NLog.Web.AspNetCore.Tests/NLog.Web.AspNetCore.Tests.csproj
+++ b/NLog.Web.AspNetCore.Tests/NLog.Web.AspNetCore.Tests.csproj
@@ -32,10 +32,7 @@
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="1.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="1.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="1.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="1.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="1.1.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp1.1' ">
     <PackageReference Include="Microsoft.AspNetCore" Version="2.0.1" />

--- a/NLog.Web.AspNetCore/AspNetExtensions.cs
+++ b/NLog.Web.AspNetCore/AspNetExtensions.cs
@@ -33,6 +33,8 @@ namespace NLog.Web
         public static void AddNLogWeb(this IApplicationBuilder app)
         {
             ServiceLocator.ServiceProvider = app.ApplicationServices;
+            ConfigurationItemFactory.Default.RegisterItemsFromAssembly(typeof(AspNetExtensions).GetTypeInfo().Assembly);
+            LogManager.AddHiddenAssembly(typeof(AspNetExtensions).GetTypeInfo().Assembly);
         }
 
         /// <summary>
@@ -43,6 +45,8 @@ namespace NLog.Web
         /// <returns>LoggingConfiguration for chaining</returns>
         public static LoggingConfiguration ConfigureNLog(this IHostingEnvironment env, string configFileRelativePath)
         {
+            ConfigurationItemFactory.Default.RegisterItemsFromAssembly(typeof(AspNetExtensions).GetTypeInfo().Assembly);
+            LogManager.AddHiddenAssembly(typeof(AspNetExtensions).GetTypeInfo().Assembly);
             var fileName = Path.Combine(env.ContentRootPath, configFileRelativePath);
             LogManager.LoadConfiguration(fileName);
             return LogManager.Configuration;


### PR DESCRIPTION
No longer need to add this for NetCoreApp1:

```
  <!-- Load the ASP.NET Core plugin -->
  <extensions>
    <add assembly="NLog.Web.AspNetCore"/>
  </extensions>
```

Guess the wiki-page has to be updated.