### PR TITLE
Configured xunit DisableTestParallelization to make tests more stable

### DIFF
--- a/NLog.Web.AspNetCore.Tests/Properties/AssemblyInfo-test.cs
+++ b/NLog.Web.AspNetCore.Tests/Properties/AssemblyInfo-test.cs
@@ -1,0 +1,14 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+[assembly: Xunit.CollectionBehavior(DisableTestParallelization = true)]

--- a/NLog.Web.Tests/Properties/AssemblyInfo-test.cs
+++ b/NLog.Web.Tests/Properties/AssemblyInfo-test.cs
@@ -34,3 +34,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.2.3.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+
+[assembly: Xunit.CollectionBehavior(DisableTestParallelization = true)]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,4 @@
+version: 4.5.0.{build}
 clone_folder: c:\projects\nlogweb
 configuration: Release
 image: Visual Studio 2017


### PR DESCRIPTION
Configured xunit to `DisableTestParallelization` (Attempt to make tests less flaky)

And discovered removing `version` affected the build-names:

https://ci.appveyor.com/project/nlog/nlog-web/history