### PR TITLE
ConfigureNLog should not be used together with UseNLog

### DIFF
--- a/NLog.Web.AspNetCore/AspNetExtensions.cs
+++ b/NLog.Web.AspNetCore/AspNetExtensions.cs
@@ -7,9 +7,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using NLog.Config;
-using NLog.Web.Internal;
 using NLog.Extensions.Logging;
-using NLog.Web.AspNetCore;
 using NLog.Web.DependencyInjection;
 
 #if ASP_NET_CORE2
@@ -62,6 +60,7 @@ namespace NLog.Web
         /// <param name="builder">The logging builder</param>
         /// <param name="configFileName">Path to NLog configuration file, e.g. nlog.config. </param>>
         /// <returns>LogFactory to get loggers, add events etc</returns>
+        [Obsolete("Use UseNLog() on IWebHostBuilder, and NLog.LogManager.LoadConfiguration()")]
         public static LogFactory ConfigureNLog(this ILoggingBuilder builder, string configFileName)
         {
             builder.AddNLog();
@@ -76,6 +75,7 @@ namespace NLog.Web
         /// <param name="builder">The logging builder</param>
         /// <param name="configuration">Config for NLog</param>
         /// <returns>LogFactory to get loggers, add events etc</returns>
+        [Obsolete("Use UseNLog() on IWebHostBuilder, and assign property NLog.LogManager.Configuration")]
         public static LogFactory ConfigureNLog(this ILoggingBuilder builder, LoggingConfiguration configuration)
         {
             builder.AddNLog();
@@ -116,12 +116,9 @@ namespace NLog.Web
                 {
                     services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
                 }
-
             });
-
             return builder;
         }
-
 #endif
 
     }

--- a/NLog.Web.AspNetCore/Internal/RequestAccessorExtension.cs
+++ b/NLog.Web.AspNetCore/Internal/RequestAccessorExtension.cs
@@ -22,7 +22,7 @@ namespace NLog.Web.Internal
             }
             catch (HttpException ex)
             {
-                InternalLogger.Debug("Exception thrown when accessing Request: " + ex);
+                InternalLogger.Debug(ex, "Exception thrown when accessing Request: " + ex.Message);
                 return null;
             }
         }


### PR DESCRIPTION
`UseNLog` together with `ConfigureNLog` will generate duplicate logging (builder.AddNLog will register a second time). 

See also:

https://stackoverflow.com/questions/33613971/nlog-logs-error-twice-in-same-file
https://stackoverflow.com/questions/42589841/how-can-i-stop-nlog-from-double-logging

I guess registering an ILoggerFactory as singleton (That ignores any calls to `AddProvider`) would also solve the issue (Making it more difficult to configure wrong). See also #235