### PR TITLE
NLogBuilder is needed, because DLL autoload doesn't work

### DIFF
--- a/NLog.Web.AspNetCore/AspNetExtensions.cs
+++ b/NLog.Web.AspNetCore/AspNetExtensions.cs
@@ -116,8 +116,28 @@ namespace NLog.Web
                 {
                     services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
                 }
+
+                RegisterHiddenAssembliesForCallSite();
             });
             return builder;
+        }
+
+        private static void RegisterHiddenAssembliesForCallSite()
+        {
+            var allAssemblies = AppDomain.CurrentDomain.GetAssemblies();
+            foreach (var assembly in allAssemblies)
+            {
+                if ( assembly.FullName.StartsWith("NLog.Extensions.Logging,", StringComparison.OrdinalIgnoreCase)
+                    || assembly.FullName.StartsWith("NLog.Web,", StringComparison.OrdinalIgnoreCase)
+                    || assembly.FullName.StartsWith("NLog.Web.AspNetCore,", StringComparison.OrdinalIgnoreCase)
+                    || assembly.FullName.StartsWith("Microsoft.Extensions.Logging,", StringComparison.OrdinalIgnoreCase)
+                    || assembly.FullName.StartsWith("Microsoft.Extensions.Logging.Abstractions,", StringComparison.OrdinalIgnoreCase)
+                    || assembly.FullName.StartsWith("Microsoft.Extensions.Logging.Filter,", StringComparison.OrdinalIgnoreCase)
+                    || assembly.FullName.StartsWith("Microsoft.Logging,", StringComparison.OrdinalIgnoreCase))
+                {
+                    LogManager.AddHiddenAssembly(assembly);
+                }
+            }
         }
 #endif
 

--- a/NLog.Web.AspNetCore/NLogBuilder.cs
+++ b/NLog.Web.AspNetCore/NLogBuilder.cs
@@ -1,11 +1,7 @@
-﻿#if ASP_NET_CORE2
-
+﻿#if ASP_NET_CORE
 using System;
-using System.Collections.Generic;
 using System.Reflection;
-using NLog.Common;
 using NLog.Config;
-using NLog.Extensions.Logging;
 
 namespace NLog.Web
 {
@@ -19,9 +15,9 @@ namespace NLog.Web
         /// </summary>
         /// <param name="configFileName">Path to NLog configuration file, e.g. nlog.config. </param>>
         /// <returns>LogFactory to get loggers, add events etc</returns>
-        [Obsolete("Instead use NLog.LogManager.LoadConfiguration()")]
         public static LogFactory ConfigureNLog(string configFileName)
         {
+            ConfigurationItemFactory.Default.RegisterItemsFromAssembly(typeof(AspNetExtensions).GetTypeInfo().Assembly);
             return LogManager.LoadConfiguration(configFileName);
         }
 
@@ -30,9 +26,9 @@ namespace NLog.Web
         /// </summary>
         /// <param name="configuration">Config for NLog</param>
         /// <returns>LogFactory to get loggers, add events etc</returns>
-        [Obsolete("Instead assign property NLog.LogManager.Configuration")]
         public static LogFactory ConfigureNLog(LoggingConfiguration configuration)
         {
+            ConfigurationItemFactory.Default.RegisterItemsFromAssembly(typeof(AspNetExtensions).GetTypeInfo().Assembly);
             LogManager.Configuration = configuration;
             return LogManager.LogFactory;
         }

--- a/examples/ASP.NET Core 2/Visual Studio 2017/ASP.NET Core 2 - VS2017/Program.cs
+++ b/examples/ASP.NET Core 2/Visual Studio 2017/ASP.NET Core 2 - VS2017/Program.cs
@@ -11,7 +11,7 @@ namespace NLog.Web.AspNetCore2.Example
     {
         public static void Main(string[] args)
         {
-            var logger = NLog.LogManager.LoadConfiguration("nlog.config").GetCurrentClassLogger();
+            var logger = NLog.Web.NLogBuilder.ConfigureNLog("nlog.config").GetCurrentClassLogger();
             try
             {
                 logger.Debug("init main");
@@ -38,7 +38,7 @@ namespace NLog.Web.AspNetCore2.Example
                     logging.ClearProviders();
                     logging.SetMinimumLevel(Microsoft.Extensions.Logging.LogLevel.Trace);
                 })
-                .UseNLog()  // NLog: setup NLog for Dependency injection
+                .UseNLog()  // NLog: Setup NLog for Dependency injection
                 .Build();
     }
 }


### PR DESCRIPTION
unless the DLL has been loaded.

Resolves #267 + Resolves #264 

The example project was cheating as it had a direct reference to "NLog.Web.AspNetCore". After removing project-reference and using nuget-package, then it pre-loaded differently.