### PR TITLE
Avoid assembly lookup on static class initialization

### DIFF
--- a/NLog.Web.AspNetCore/AspNetExtensions.cs
+++ b/NLog.Web.AspNetCore/AspNetExtensions.cs
@@ -21,8 +21,6 @@ namespace NLog.Web
     /// </summary>
     public static class AspNetExtensions
     {
-        private static readonly Assembly _nlogWebAssembly = typeof(AspNetExtensions).GetTypeInfo().Assembly;
-
         /// <summary>
         /// Enable NLog Web for ASP.NET Core.
         /// </summary>
@@ -43,8 +41,8 @@ namespace NLog.Web
         /// <returns>LoggingConfiguration for chaining</returns>
         public static LoggingConfiguration ConfigureNLog(this IHostingEnvironment env, string configFileRelativePath)
         {
-            ConfigurationItemFactory.Default.RegisterItemsFromAssembly(_nlogWebAssembly);
-            LogManager.AddHiddenAssembly(_nlogWebAssembly);
+            ConfigurationItemFactory.Default.RegisterItemsFromAssembly(typeof(AspNetExtensions).GetTypeInfo().Assembly);
+            LogManager.AddHiddenAssembly(typeof(AspNetExtensions).GetTypeInfo().Assembly);
             var fileName = Path.Combine(env.ContentRootPath, configFileRelativePath);
             LogManager.LoadConfiguration(fileName);
             return LogManager.Configuration;
@@ -63,7 +61,7 @@ namespace NLog.Web
         [Obsolete("Use UseNLog() on IWebHostBuilder, and NLog.Web.NLogBuilder.ConfigureNLog()")]
         public static LogFactory ConfigureNLog(this ILoggingBuilder builder, string configFileName)
         {
-            ConfigurationItemFactory.Default.RegisterItemsFromAssembly(_nlogWebAssembly);
+            ConfigurationItemFactory.Default.RegisterItemsFromAssembly(typeof(AspNetExtensions).GetTypeInfo().Assembly);
             builder.AddNLog();
             return LogManager.LoadConfiguration(configFileName);
         }
@@ -79,7 +77,7 @@ namespace NLog.Web
         [Obsolete("Use UseNLog() on IWebHostBuilder, and NLog.Web.NLogBuilder.ConfigureNLog()")]
         public static LogFactory ConfigureNLog(this ILoggingBuilder builder, LoggingConfiguration configuration)
         {
-            ConfigurationItemFactory.Default.RegisterItemsFromAssembly(_nlogWebAssembly);
+            ConfigurationItemFactory.Default.RegisterItemsFromAssembly(typeof(AspNetExtensions).GetTypeInfo().Assembly);
             builder.AddNLog();
             LogManager.Configuration = configuration;
             return LogManager.LogFactory;
@@ -104,11 +102,11 @@ namespace NLog.Web
             if (builder == null) throw new ArgumentNullException(nameof(builder));
             options = options ?? NLogAspNetCoreOptions.Default;
             
-            ConfigurationItemFactory.Default.RegisterItemsFromAssembly(_nlogWebAssembly);
-            LogManager.AddHiddenAssembly(_nlogWebAssembly);
-
             builder.ConfigureServices(services =>
             {
+                ConfigurationItemFactory.Default.RegisterItemsFromAssembly(typeof(AspNetExtensions).GetTypeInfo().Assembly);
+                LogManager.AddHiddenAssembly(typeof(AspNetExtensions).GetTypeInfo().Assembly);
+
                 //note: when registering ILoggerFactory, all non NLog stuff and stuff before this will be removed
                 services.AddSingleton<ILoggerProvider>(serviceProvider =>
                 {
@@ -137,8 +135,8 @@ namespace NLog.Web
         public static IServiceProvider SetupNLogServiceLocator(this IServiceProvider serviceProvider)
         {
             ServiceLocator.ServiceProvider = serviceProvider;
-            ConfigurationItemFactory.Default.RegisterItemsFromAssembly(_nlogWebAssembly);
-            LogManager.AddHiddenAssembly(_nlogWebAssembly);
+            ConfigurationItemFactory.Default.RegisterItemsFromAssembly(typeof(AspNetExtensions).GetTypeInfo().Assembly);
+            LogManager.AddHiddenAssembly(typeof(AspNetExtensions).GetTypeInfo().Assembly);
             return serviceProvider;
         }
     }


### PR DESCRIPTION
Guessing that Assembly lookup during startup is not welcome. Trying to resolve #281 

Another example of assembly lookup during startup is failing for ServiceFabric: https://github.com/quartznet/quartznet/issues/619 (Though here the bug is in `SerilogLogProvider.IsLoggerAvailable`)