### PR TITLE
Value only aspnet request cookie

### DIFF
--- a/NLog.Web.AspNetCore.Tests/LayoutRenderers/AspNetCookieLayoutRendererTests.cs
+++ b/NLog.Web.AspNetCore.Tests/LayoutRenderers/AspNetCookieLayoutRendererTests.cs
@@ -32,7 +32,6 @@ namespace NLog.Web.Tests.LayoutRenderers
     {
         public AspNetCookieLayoutRendererTests() : base()
         {
-
         }
 
         [Fact]
@@ -60,8 +59,6 @@ namespace NLog.Web.Tests.LayoutRenderers
             Assert.Empty(result);
         }
 
-
-
         [Fact]
         public void KeyNotFoundRendersEmptyString_Json_Formatting()
         {
@@ -75,7 +72,7 @@ namespace NLog.Web.Tests.LayoutRenderers
         }
 
         [Fact]
-        public void KeyFoundRendersValue_Cookie_Mulitple_Items_Flat_Formatting()
+        public void KeyFoundRendersValue_Cookie_Multiple_Items_Flat_Formatting()
         {
 #if ASP_NET_CORE
             //no multivalue keys in ASP.NET core
@@ -90,7 +87,6 @@ namespace NLog.Web.Tests.LayoutRenderers
 
             Assert.Equal(expectedResult, result);
         }
-
 
         [Fact]
         public void KeyFoundRendersValue_Cookie_Multiple_Items_Flat_Formatting_separators()
@@ -155,7 +151,7 @@ namespace NLog.Web.Tests.LayoutRenderers
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public void KeyFoundRendersValue_Cookie_Mulitple_Items_Json_Formatting(bool singleAsArray)
+        public void KeyFoundRendersValue_Cookie_Multiple_Items_Json_Formatting(bool singleAsArray)
         {
             var expectedResult = "[{\"key\":\"TEST\"},{\"Key1\":\"TEST1\"}]";
 
@@ -169,11 +165,137 @@ namespace NLog.Web.Tests.LayoutRenderers
             Assert.Equal(expectedResult, result);
         }
 
+        [Fact]
+        public void KeyNotFoundRendersEmptyString_Flat_Formatting_ValuesOnly()
+        {
+            var renderer = CreateRenderer();
+            renderer.OutputFormat = AspNetRequestLayoutOutputFormat.Flat;
+            renderer.CookieNames = new List<string> { "notfound" };
+            renderer.ValuesOnly = true;
+
+            string result = renderer.Render(new LogEventInfo());
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void KeyNotFoundRendersEmptyString_Json_Formatting_ValuesOnly()
+        {
+            var renderer = CreateRenderer();
+            renderer.OutputFormat = AspNetRequestLayoutOutputFormat.Json;
+            renderer.CookieNames = new List<string> { "notfound" };
+            renderer.ValuesOnly = true;
+
+            string result = renderer.Render(new LogEventInfo());
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void KeyFoundRendersValue_Cookie_Multiple_Items_Flat_Formatting_ValuesOnly()
+        {
+#if ASP_NET_CORE
+            //no multivalue keys in ASP.NET core
+            var expectedResult = "TEST,TEST1";
+#else
+            var expectedResult = "TEST&TEST1";
+#endif
+
+            var renderer = CreateRenderer();
+            renderer.ValuesOnly = true;
+
+            string result = renderer.Render(new LogEventInfo());
+
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public void KeyFoundRendersValue_Cookie_Multiple_Items_Flat_Formatting_separators_ValuesOnly()
+        {
+#if ASP_NET_CORE
+            //no multivalue keys in ASP.NET core
+            var expectedResult = "TEST|TEST1";
+#else
+            var expectedResult = "TEST&TEST1"; 
+#endif
+
+            var renderer = CreateRenderer();
+            renderer.ValueSeparator = ":";
+            renderer.ItemSeparator = "|";
+            renderer.ValuesOnly = true;
+
+            string result = renderer.Render(new LogEventInfo());
+
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public void KeyFoundRendersValue_Single_Item_Flat_Formatting_ValuesOnly()
+        {
+            var expectedResult = "TEST";
+
+            var renderer = CreateRenderer(addKey: false);
+            renderer.ValuesOnly = true;
+
+            string result = renderer.Render(new LogEventInfo());
+
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public void KeyFoundRendersValue_Single_Item_Json_Formatting_ValuesOnly()
+        {
+            var expectedResult = "[\"TEST\"]";
+
+            var renderer = CreateRenderer(addKey: false);
+            renderer.OutputFormat = AspNetRequestLayoutOutputFormat.Json;
+            renderer.ValuesOnly = true;
+
+            string result = renderer.Render(new LogEventInfo());
+
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public void KeyFoundRendersValue_Single_Item_Json_Formatting_no_array_ValuesOnly()
+        {
+            // With ValuesOnly enabled, only arrays are valid
+            var expectedResult = "[\"TEST\"]";
+
+            var renderer = CreateRenderer(addKey: false);
+
+            renderer.OutputFormat = AspNetRequestLayoutOutputFormat.Json;
+            renderer.SingleAsArray = false;
+            renderer.ValuesOnly = true;
+
+            string result = renderer.Render(new LogEventInfo());
+
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void KeyFoundRendersValue_Cookie_Multiple_Items_Json_Formatting_ValuesOnly(bool singleAsArray)
+        {
+            var expectedResult = "[\"TEST\",\"TEST1\"]";
+
+            var renderer = CreateRenderer();
+
+            renderer.OutputFormat = AspNetRequestLayoutOutputFormat.Json;
+            renderer.SingleAsArray = singleAsArray;
+            renderer.ValuesOnly = true;
+
+            string result = renderer.Render(new LogEventInfo());
+
+            Assert.Equal(expectedResult, result);
+        }
+
 //no multivalue keys in ASP.NET core
 #if !ASP_NET_CORE
 
         [Fact]
-        public void KeyFoundRendersVakue_Cookie_Mulitple_Cookies_Cookie_Items_Flat_Formatting()
+        public void KeyFoundRendersVakue_Cookie_Multiple_Cookies_Cookie_Items_Flat_Formatting()
         {
             var expectedResult = "key=TEST&Key1=TEST1,key2=Test&key3=Test456";
 
@@ -187,7 +309,7 @@ namespace NLog.Web.Tests.LayoutRenderers
         }
 
         [Fact]
-        public void KeyFoundRendersVakue_Cookie_Mulitple_Cookies_Cookie_Items_Json_Formatting()
+        public void KeyFoundRendersVakue_Cookie_Multiple_Cookies_Cookie_Items_Json_Formatting()
         {
             var expectedResult = "[{\"key\":\"TEST\"},{\"Key1\":\"TEST1\"},{\"key2\":\"Test\"},{\"key3\":\"Test456\"}]";
             var renderer = CreateRenderer(addCookie2: true);
@@ -202,7 +324,7 @@ namespace NLog.Web.Tests.LayoutRenderers
 #if !ASP_NET_CORE //todo
 
         [Fact]
-        public void CommaSeperatedCookieNamesTest_Mulitple_FLAT_Formatting()
+        public void CommaSeperatedCookieNamesTest_Multiple_FLAT_Formatting()
         {
             var expectedResult = "key=TEST&Key1=TEST1";
 
@@ -230,7 +352,7 @@ namespace NLog.Web.Tests.LayoutRenderers
         }
 
         [Fact]
-        public void CommaSeperatedCookieNamesTest_Mulitple_Json_Formatting()
+        public void CommaSeperatedCookieNamesTest_Multiple_Json_Formatting()
         {
             var expectedResult = "[{\"key\":\"TEST\"},{\"Key1\":\"TEST1\"}]";
 

--- a/NLog.Web.AspNetCore/LayoutRenderers/AspNetLayoutMultiValueRendererBase.cs
+++ b/NLog.Web.AspNetCore/LayoutRenderers/AspNetLayoutMultiValueRendererBase.cs
@@ -35,29 +35,27 @@ namespace NLog.Web.LayoutRenderers
         public AspNetRequestLayoutOutputFormat OutputFormat { get; set; } = AspNetRequestLayoutOutputFormat.Flat;
 
         /// <summary>
-        /// Serialize multiple values
+        /// Serialize multiple values in pairs format.
         /// </summary>
-        /// <param name="values">The values with key and value.</param>
+        /// <param name="pairs">The key value pairs to serialize.</param>
         /// <param name="builder">Add to this builder.</param>
-        protected void SerializeValues(IEnumerable<KeyValuePair<string, string>> values,
-            StringBuilder builder)
+        protected void SerializePairs(IEnumerable<KeyValuePair<string, string>> pairs, StringBuilder builder)
         {
-
             switch (OutputFormat)
             {
                 case AspNetRequestLayoutOutputFormat.Flat:
-                    SerializValuesFlat(values, builder);
+                    SerializePairsFlat(pairs, builder);
                     break;
                 case AspNetRequestLayoutOutputFormat.Json:
-                    SerializeValuesJson(values, builder);
+                    SerializePairsJson(pairs, builder);
                     break;
             }
         }
 
-        private void SerializeValuesJson(IEnumerable<KeyValuePair<string, string>> values, StringBuilder builder)
+        private void SerializePairsJson(IEnumerable<KeyValuePair<string, string>> pairs, StringBuilder builder)
         {
             var firstItem = true;
-            var valueList = values.ToList();
+            var valueList = pairs.ToList();
 
             if (valueList.Count > 0)
             {
@@ -92,13 +90,12 @@ namespace NLog.Web.LayoutRenderers
                     builder.Append(']');
                 }
             }
-
         }
 
-        private void SerializValuesFlat(IEnumerable<KeyValuePair<string, string>> values, StringBuilder builder)
+        private void SerializePairsFlat(IEnumerable<KeyValuePair<string, string>> pairs, StringBuilder builder)
         {
             var firstItem = true;
-            foreach (var kpv in values)
+            foreach (var kpv in pairs)
             {
                 var key = kpv.Key;
                 var value = kpv.Value;
@@ -111,6 +108,72 @@ namespace NLog.Web.LayoutRenderers
                 builder.Append(key);
                 builder.Append(ValueSeparator);
                 builder.Append(value);
+            }
+        }
+
+        /// <summary>
+        /// Serialize values only from the given pairs.
+        /// </summary>
+        /// <param name="pairs">The key value pairs to serialize.</param>
+        /// <param name="builder">Add to this builder.</param>
+        protected void SerializeValues(IEnumerable<KeyValuePair<string, string>> pairs, StringBuilder builder)
+        {
+            switch (OutputFormat)
+            {
+                case AspNetRequestLayoutOutputFormat.Flat:
+                    SerializeValuesFlat(pairs, builder);
+                    break;
+                case AspNetRequestLayoutOutputFormat.Json:
+                    SerializeValuesJson(pairs, builder);
+                    break;
+            }
+        }
+
+        private void SerializeValuesFlat(IEnumerable<KeyValuePair<string, string>> pairs, StringBuilder builder)
+        {
+            var firstItem = true;
+            foreach (var kpv in pairs)
+            {
+                var value = kpv.Value;
+
+                if (!firstItem)
+                {
+                    builder.Append(ItemSeparator);
+                }
+                firstItem = false;
+                builder.Append(value);
+            }
+        }
+
+        private void SerializeValuesJson(IEnumerable<KeyValuePair<string, string>> pairs, StringBuilder builder)
+        {
+            var firstItem = true;
+            var valueList = pairs.ToList();
+
+            if (valueList.Count > 0)
+            {
+                var addArray = valueList.Count > (SingleAsArray ? 0 : 1);
+
+                if (addArray)
+                {
+                    builder.Append('[');
+                }
+
+                foreach (var kpv in valueList)
+                {
+                    var value = kpv.Value;
+                    if (!firstItem)
+                    {
+                        builder.Append(',');
+                    }
+                    firstItem = false;
+
+                    AppendQuoted(builder, value);
+                }
+                if (addArray)
+                {
+                    builder.Append(']');
+                }
             }
         }
 

--- a/NLog.Web.AspNetCore/LayoutRenderers/AspNetLayoutMultiValueRendererBase.cs
+++ b/NLog.Web.AspNetCore/LayoutRenderers/AspNetLayoutMultiValueRendererBase.cs
@@ -152,12 +152,7 @@ namespace NLog.Web.LayoutRenderers
 
             if (valueList.Count > 0)
             {
-                var addArray = valueList.Count > (SingleAsArray ? 0 : 1);
-
-                if (addArray)
-                {
-                    builder.Append('[');
-                }
+                builder.Append('[');
 
                 foreach (var kpv in valueList)
                 {
@@ -170,10 +165,8 @@ namespace NLog.Web.LayoutRenderers
 
                     AppendQuoted(builder, value);
                 }
-                if (addArray)
-                {
-                    builder.Append(']');
-                }
+
+                builder.Append(']');
             }
         }
 

--- a/NLog.Web.AspNetCore/LayoutRenderers/AspNetRequestCookieLayoutRenderer.cs
+++ b/NLog.Web.AspNetCore/LayoutRenderers/AspNetRequestCookieLayoutRenderer.cs
@@ -36,6 +36,11 @@ namespace NLog.Web.LayoutRenderers
         public List<string> CookieNames { get; set; }
 
         /// <summary>
+        /// Only render cookie values if true, otherwise render key value pairs.
+        /// </summary>
+        public bool ValuesOnly { get; set; }
+
+        /// <summary>
         /// Renders the ASP.NET Cookie appends it to the specified <see cref="StringBuilder" />.
         /// </summary>
         /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
@@ -53,8 +58,15 @@ namespace NLog.Web.LayoutRenderers
 
             if (this.CookieNames?.Count > 0 && cookies?.Count > 0)
             {
-                var cookieValues = GetCookies(cookies);
-                SerializeValues(cookieValues, builder);
+                var cookieKeyValuePairs = GetCookies(cookies);
+                if (!ValuesOnly)
+                {
+                    SerializePairs(cookieKeyValuePairs, builder);
+                }
+                else
+                {
+                    SerializeValues(cookieKeyValuePairs, builder);
+                }
             }
         }
 

--- a/NLog.Web.AspNetCore/LayoutRenderers/AspNetRequestQueryStringLayoutRenderer.cs
+++ b/NLog.Web.AspNetCore/LayoutRenderers/AspNetRequestQueryStringLayoutRenderer.cs
@@ -82,7 +82,7 @@ namespace NLog.Web.LayoutRenderers
 #endif
 
             var values = GetValues(queryStrings, queryStringKeys);
-            SerializeValues(values, builder);
+            SerializePairs(values, builder);
         }
 
         private static IEnumerable<KeyValuePair<string, string>> GetValues(


### PR DESCRIPTION
Fixes #294 by adding a "ValuesOnly" option to the ${aspnet-request-cookie} renderer, with associated unit tests.

Also:
* clarifies naming of some methods/parameters where the word "values" is used
* fixes some typos / inconsistent spacing