### PR TITLE
CookieLayoutRenderer unit test clean up

### DIFF
--- a/NLog.Web.AspNetCore.Tests/FakeHttpContextAccessor.cs
+++ b/NLog.Web.AspNetCore.Tests/FakeHttpContextAccessor.cs
@@ -15,11 +15,20 @@ namespace NLog.Web.Tests
     /// </summary>
     public class FakeHttpContextAccessor : IHttpContextAccessor
     {
+#if ASP_NET_CORE
+        public HttpContext HttpContext { get; set; }
+
+        public FakeHttpContextAccessor(HttpContext httpContext)
+        {
+            HttpContext = httpContext;
+        }
+#else
         public HttpContextBase HttpContext { get; set; }
 
         public FakeHttpContextAccessor(HttpContextBase httpContext)
         {
             HttpContext = httpContext;
         }
+#endif
     }
 }

--- a/NLog.Web.AspNetCore.Tests/LayoutRenderers/AspNetCookieLayoutRendererTests.cs
+++ b/NLog.Web.AspNetCore.Tests/LayoutRenderers/AspNetCookieLayoutRendererTests.cs
@@ -32,7 +32,6 @@ namespace NLog.Web.Tests.LayoutRenderers
     {
         public AspNetCookieLayoutRendererTests() : base()
         {
-
         }
 
         [Fact]
@@ -58,12 +57,11 @@ namespace NLog.Web.Tests.LayoutRenderers
             var renderer = CreateRenderer();
             renderer.OutputFormat = AspNetRequestLayoutOutputFormat.Flat;
             renderer.CookieNames = new List<string> { "notfound" };
+
             string result = renderer.Render(new LogEventInfo());
 
             Assert.Empty(result);
         }
-
-
 
         [Fact]
         public void KeyNotFoundRendersEmptyString_Json_Formatting()
@@ -132,7 +130,6 @@ namespace NLog.Web.Tests.LayoutRenderers
             var expectedResult = "[{\"key\":\"TEST\"}]";
 
             var renderer = CreateRenderer(addSecondCookie: false);
-
             renderer.OutputFormat = AspNetRequestLayoutOutputFormat.Json;
 
             string result = renderer.Render(new LogEventInfo());
@@ -146,7 +143,6 @@ namespace NLog.Web.Tests.LayoutRenderers
             var expectedResult = "{\"key\":\"TEST\"}";
 
             var renderer = CreateRenderer(addSecondCookie: false);
-
             renderer.OutputFormat = AspNetRequestLayoutOutputFormat.Json;
             renderer.SingleAsArray = false;
 
@@ -163,7 +159,6 @@ namespace NLog.Web.Tests.LayoutRenderers
             var expectedResult = "[{\"key\":\"TEST\"},{\"Key1\":\"TEST1\"}]";
 
             var renderer = CreateRenderer();
-
             renderer.OutputFormat = AspNetRequestLayoutOutputFormat.Json;
             renderer.SingleAsArray = singleAsArray;
 
@@ -176,12 +171,11 @@ namespace NLog.Web.Tests.LayoutRenderers
 #if !ASP_NET_CORE
 
         [Fact]
-        public void KeyFoundRendersValue_Cookie_Multiple_Cookies_Cookie_Items_Flat_Formatting()
+        public void KeyFoundRendersValue_Multiple_Cookies_And_Cookie_Values_Flat_Formatting()
         {
             var expectedResult = "key=TEST&Key1=TEST1,key2=Test&key3=Test456";
 
             var renderer = CreateRenderer(addMultiValueCookieKey: true);
-
             renderer.CookieNames = new List<string> { "key", "key2" };
 
             string result = renderer.Render(new LogEventInfo());
@@ -190,7 +184,7 @@ namespace NLog.Web.Tests.LayoutRenderers
         }
 
         [Fact]
-        public void KeyFoundRendersValue_Cookie_Multiple_Cookies_Cookie_Items_Json_Formatting()
+        public void KeyFoundRendersValue_Multiple_Cookies_And_Cookie_Values_Json_Formatting()
         {
             var expectedResult = "[{\"key\":\"TEST\"},{\"Key1\":\"TEST1\"},{\"key2\":\"Test\"},{\"key3\":\"Test456\"}]";
             var renderer = CreateRenderer(addMultiValueCookieKey: true);
@@ -205,7 +199,7 @@ namespace NLog.Web.Tests.LayoutRenderers
 #if !ASP_NET_CORE //todo
 
         [Fact]
-        public void CommaSeperatedCookieNamesTest_Multiple_FLAT_Formatting()
+        public void CommaSeperatedCookieNamesTest_Multiple_Cookie_Values_Flat_Formatting()
         {
             var expectedResult = "key=TEST&Key1=TEST1";
 
@@ -233,7 +227,7 @@ namespace NLog.Web.Tests.LayoutRenderers
         }
 
         [Fact]
-        public void CommaSeperatedCookieNamesTest_Multiple_Json_Formatting()
+        public void CommaSeperatedCookieNamesTest_Multiple_Cookie_Values_Json_Formatting()
         {
             var expectedResult = "[{\"key\":\"TEST\"},{\"Key1\":\"TEST1\"}]";
 

--- a/NLog.Web.AspNetCore.Tests/LayoutRenderers/AspNetCookieLayoutRendererTests.cs
+++ b/NLog.Web.AspNetCore.Tests/LayoutRenderers/AspNetCookieLayoutRendererTests.cs
@@ -308,8 +308,7 @@ namespace NLog.Web.Tests.LayoutRenderers
 
             if (addMultiValueCookieKey)
             {
-                AddCookie("key2", "Test");
-                AddCookie("key3", "Test456");
+                throw new NotSupportedException("Multi-valued cookie keys are not supported in ASP.NET Core");
             }
 
 #else

--- a/NLog.Web.AspNetCore.Tests/LayoutRenderers/TestInvolvingAspNetHttpContext.cs
+++ b/NLog.Web.AspNetCore.Tests/LayoutRenderers/TestInvolvingAspNetHttpContext.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Primitives;
 using HttpContextBase = Microsoft.AspNetCore.Http.HttpContext;
 using HttpContext = Microsoft.AspNetCore.Http.HttpContext;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Internal;
 #endif
 using System.Xml;
 
@@ -23,11 +24,13 @@ namespace NLog.Web.Tests.LayoutRenderers
 {
     public abstract class TestInvolvingAspNetHttpContext : TestBase, IDisposable
     {
+        private static readonly Uri DefaultTestUri = new Uri("http://stackoverflow.com/");
+
         protected HttpContext HttpContext;
 
         protected TestInvolvingAspNetHttpContext()
         {
-            HttpContext = SetupFakeHttpContext();
+            HttpContext = SetUpFakeHttpContext();
 #if !ASP_NET_CORE
             HttpContext.Current = HttpContext;
 #endif
@@ -54,25 +57,23 @@ namespace NLog.Web.Tests.LayoutRenderers
                 return new XmlLoggingConfiguration(reader, null);
         }
 
-        protected HttpContext SetupFakeHttpContext()
-        {
 #if !ASP_NET_CORE
+
+        protected HttpContext SetUpFakeHttpContext()
+        {
             var httpRequest = SetUpHttpRequest();
-            var stringWriter = new StringWriter();
-            var httpResponse = new HttpResponse(stringWriter);
+            var httpResponse = SetUpHttpResponse();
             return new HttpContext(httpRequest, httpResponse);
-#else
-            return null;
-#endif
         }
-#if !ASP_NET_CORE
-        protected virtual HttpRequest SetUpHttpRequest(string query = "")
+
+        protected virtual HttpRequest SetUpHttpRequest(Uri uri = null)
         {
-            return new HttpRequest("", "http://stackoverflow/", query);
+            if (uri == null)
+                uri = DefaultTestUri;
+            return new HttpRequest("", uri.AbsoluteUri, uri.Query);
         }
 
-
-        protected void AddHeader(HttpRequest request, string headerName, string headerValue)
+        protected void AddRequestHeader(HttpRequest request, string headerName, string headerValue)
         {
             // thanks http://stackoverflow.com/a/13307238
             var headers = request.Headers;
@@ -93,7 +94,49 @@ namespace NLog.Web.Tests.LayoutRenderers
                 null,
                 headers, null);
         }
-      #endif
+
+        protected virtual HttpResponse SetUpHttpResponse()
+        {
+            var stringWriter = new StringWriter();
+            var httpResponse = new HttpResponse(stringWriter);
+            return httpResponse;
+        }
+
+#else
+
+        protected virtual HttpContext SetUpFakeHttpContext()
+        {
+            var context = new DefaultHttpContext();
+            var httpRequest = SetUpHttpRequest(context);
+            var httpResponse = SetUpHttpResponse(context);
+            return context;
+        }
+
+        protected void AddRequestHeader(HttpRequest request, string headerName, params string[] headerValues)
+        {
+            var headers = request.Headers;
+            headers.Add(headerName, headerValues);
+        }
+
+        protected virtual HttpRequest SetUpHttpRequest(HttpContext context)
+        {
+            var httpRequest = new DefaultHttpRequest(context)
+            {
+                Scheme = DefaultTestUri.Scheme,
+                Path = DefaultTestUri.AbsolutePath,
+                Host = new HostString(DefaultTestUri.Host),
+                Method = "GET"
+            };
+            return httpRequest;
+        }
+
+        protected virtual HttpResponse SetUpHttpResponse(HttpContext context)
+        {
+            var httpResponse = new DefaultHttpResponse(context);
+            return httpResponse;
+        }
+
+#endif
 
         protected NLog.Targets.DebugTarget GetDebugTarget(string targetName, LoggingConfiguration configuration)
         {

--- a/NLog.Web.AspNetCore.Tests/LayoutRenderers/TestInvolvingAspNetHttpContext.cs
+++ b/NLog.Web.AspNetCore.Tests/LayoutRenderers/TestInvolvingAspNetHttpContext.cs
@@ -104,7 +104,7 @@ namespace NLog.Web.Tests.LayoutRenderers
 
 #else
 
-        protected virtual HttpContext SetUpFakeHttpContext()
+        protected HttpContext SetUpFakeHttpContext()
         {
             var context = new DefaultHttpContext();
             var httpRequest = SetUpHttpRequest(context);


### PR DESCRIPTION
Pre-work for #294.

* Creates a 'real' and not mocked HttpContext for use in ASP.NET Core unit tests
* Switched CookieLayoutRenderer to use this 'real' HttpContext
* Added comments about what multi-valued cookies are and their origins from Classic ASP
* Corrected incorrect namings, typos, and spacing
