### PR TITLE
Inherits AssemblyVersionLayoutRenderer from NLog implementation (ASP.NET + ASP.NET Core)

### DIFF
--- a/NLog.Web.AspNetCore.Tests/LayoutRenderers/AssemblyVersionLayoutRendererTests.cs
+++ b/NLog.Web.AspNetCore.Tests/LayoutRenderers/AssemblyVersionLayoutRendererTests.cs
@@ -13,9 +13,25 @@ namespace NLog.Web.AspNetCore.Tests.LayoutRenderers
         [Fact]
         public void AssemblyNameVersionTest()
         {
-            Layout l = "${assembly-version:NLog.Web.AspNetCore.Tests}";
-            var result = l.Render(LogEventInfo.CreateNullEvent());
+            Layout layout = "${assembly-version:NLog.Web.AspNetCore.Tests}";
+            var result = layout.Render(LogEventInfo.CreateNullEvent());
             Assert.Equal("1.2.3.0", result);
+        }
+        
+        [Fact]
+        public void AssemblyNameFileVersionTest()
+        {
+            Layout layout = "${assembly-version:name=NLog.Web.AspNetCore.Tests:type=file}";
+            var result = layout.Render(LogEventInfo.CreateNullEvent());
+            Assert.Equal("1.2.3.1", result);
+        }
+        
+        [Fact]
+        public void AssemblyNameInformationalVersionTest()
+        {
+            Layout layout = "${assembly-version:name=NLog.Web.AspNetCore.Tests:type=informational}";
+            var result = layout.Render(LogEventInfo.CreateNullEvent());
+            Assert.Equal("1.2.3.2", result);
         }
     }
 }

--- a/NLog.Web.AspNetCore.Tests/NLog.Web.AspNetCore.Tests.csproj
+++ b/NLog.Web.AspNetCore.Tests/NLog.Web.AspNetCore.Tests.csproj
@@ -3,6 +3,8 @@
     <TargetFrameworks>netcoreapp1.1;netcoreapp2;net461</TargetFrameworks>
     <AssemblyName>NLog.Web.AspNetCore.Tests</AssemblyName>
     <AssemblyVersion>1.2.3.0</AssemblyVersion>
+    <FileVersion>1.2.3.1</FileVersion>
+    <InformationalVersion>1.2.3.2</InformationalVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">

--- a/NLog.Web.AspNetCore/NLog.Web.AspNetCore.csproj
+++ b/NLog.Web.AspNetCore/NLog.Web.AspNetCore.csproj
@@ -71,6 +71,7 @@ Supported platforms:
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="NLog" Version="4.5.7" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.0.2" />
   </ItemGroup>
 

--- a/NLog.Web.Tests/NLog.Web.Tests.csproj
+++ b/NLog.Web.Tests/NLog.Web.Tests.csproj
@@ -41,7 +41,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.5.0\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.4.5.7\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="NSubstitute">
       <HintPath>..\packages\NSubstitute.2.0.3\lib\net45\NSubstitute.dll</HintPath>

--- a/NLog.Web.Tests/Properties/AssemblyInfo-test.cs
+++ b/NLog.Web.Tests/Properties/AssemblyInfo-test.cs
@@ -33,6 +33,6 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.2.3.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.2.3.1")]
 
 [assembly: Xunit.CollectionBehavior(DisableTestParallelization = true)]

--- a/NLog.Web.Tests/packages.NLog.Web.Tests.config
+++ b/NLog.Web.Tests/packages.NLog.Web.Tests.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net45" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net45" />
-  <package id="NLog" version="4.5.0" targetFramework="net45" />
+  <package id="NLog" version="4.5.7" targetFramework="net45" />
   <package id="NSubstitute" version="2.0.3" targetFramework="net45" />
   <package id="System.Collections" version="4.3.0" targetFramework="net45" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net45" />

--- a/NLog.Web/NLog.Web.csproj
+++ b/NLog.Web/NLog.Web.csproj
@@ -41,7 +41,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.5.2\lib\net35\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.4.5.7\lib\net35\NLog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/NLog.Web/packages.NLog.Web.config
+++ b/NLog.Web/packages.NLog.Web.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NLog" version="4.5.2" targetFramework="net35" />
+  <package id="NLog" version="4.5.7" targetFramework="net35" />
 </packages>

--- a/examples/ASP.NET 4.6.1/Visual Studio 2017/ASP.NET 4.6.1 - VS2017/ASP.NET 4.6.1 - VS2017.csproj
+++ b/examples/ASP.NET 4.6.1/Visual Studio 2017/ASP.NET 4.6.1 - VS2017/ASP.NET 4.6.1 - VS2017.csproj
@@ -48,7 +48,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\NLog.4.5.6\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\..\..\..\packages\NLog.4.5.7\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/examples/ASP.NET 4.6.1/Visual Studio 2017/ASP.NET 4.6.1 - VS2017/Controllers/HomeController.cs
+++ b/examples/ASP.NET 4.6.1/Visual Studio 2017/ASP.NET 4.6.1 - VS2017/Controllers/HomeController.cs
@@ -10,6 +10,8 @@ namespace NLog.Web.AspNet461.Example.Controllers
     {
         public ActionResult Index()
         {
+            NLog.LogManager.GetCurrentClassLogger().Info("Hello World");
+
             return View();
         }
 

--- a/examples/ASP.NET 4.6.1/Visual Studio 2017/ASP.NET 4.6.1 - VS2017/Global.asax.cs
+++ b/examples/ASP.NET 4.6.1/Visual Studio 2017/ASP.NET 4.6.1 - VS2017/Global.asax.cs
@@ -16,8 +16,6 @@ namespace NLog.Web.AspNet461.Example
             FilterConfig.RegisterGlobalFilters(GlobalFilters.Filters);
             RouteConfig.RegisterRoutes(RouteTable.Routes);
             BundleConfig.RegisterBundles(BundleTable.Bundles);
-
-            NLog.LogManager.GetCurrentClassLogger().Info("Hello World");
         }
     }
 }

--- a/examples/ASP.NET 4.6.1/Visual Studio 2017/ASP.NET 4.6.1 - VS2017/Properties/AssemblyInfo.cs
+++ b/examples/ASP.NET 4.6.1/Visual Studio 2017/ASP.NET 4.6.1 - VS2017/Properties/AssemblyInfo.cs
@@ -32,4 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Revision and Build Numbers
 // by using the '*' as shown below:
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.1")]
+[assembly: AssemblyInformationalVersion("1.0.0.2")]

--- a/examples/ASP.NET 4.6.1/Visual Studio 2017/ASP.NET 4.6.1 - VS2017/packages.config
+++ b/examples/ASP.NET 4.6.1/Visual Studio 2017/ASP.NET 4.6.1 - VS2017/packages.config
@@ -15,7 +15,7 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net461" />
   <package id="Modernizr" version="2.8.3" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net461" />
-  <package id="NLog" version="4.5.6" targetFramework="net461" />
+  <package id="NLog" version="4.5.7" targetFramework="net461" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.4.1" targetFramework="net461" />
   <package id="WebGrease" version="1.6.0" targetFramework="net461" />
 </packages>

--- a/examples/ASP.NET Core 2/Visual Studio 2017/ASP.NET Core 2 - VS2017/ASP.NET Core 2 - VS2017.csproj
+++ b/examples/ASP.NET Core 2/Visual Studio 2017/ASP.NET Core 2 - VS2017/ASP.NET Core 2 - VS2017.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>NLog.Web.AspNetCore2.Example</AssemblyName>
     <RootNamespace>NLog.Web.AspNetCore2.Example</RootNamespace>
+    <FileVersion>1.0.0.1</FileVersion>
+    <InformationalVersion>1.0.0.2</InformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #293 and NLog/NLog#2783.

Tested with unit tests, and example projects for ASP.NET Core 2.x and .NET Framework 4.6.

NOTE: merging this will mean NLog 4.5.7 is now required as minimum for NLog.Web to work correctly.