### PR TITLE
Fix Opencover install

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ deploy:
   on:
     branch: master
 test_script:
-  - nuget.exe install OpenCover -ExcludeVersion
+  - nuget.exe install OpenCover -ExcludeVersion -DependencyVersion Ignore
   - OpenCover\tools\OpenCover.Console.exe -register:user -target:"%xunit20%\xunit.console.x86.exe" -targetargs:"\"c:\projects\nlogweb\NLog.Web.Tests\bin\Release\NLog.Web.Tests.dll\" -appveyor -noshadow"  -returntargetcode -filter:"+[NLog.Web]*" -excludebyattribute:*.ExcludeFromCodeCoverage* -hideskipped:All -output:coverage.xml
   - pip install codecov
   - codecov -f "coverage.xml"


### PR DESCRIPTION
fixes:

> Attempting to gather dependency information for package 'OpenCover.4.6.519' with respect to project 'C:\projects\nlogweb', targeting 'Any,Version=v0.0'
Gathering dependency information took 251.85 ms
Attempting to resolve dependencies for package 'OpenCover.4.6.519' with DependencyBehavior 'Lowest'
Unable to find package 'NLog.Web'. Existing packages must be restored before performing an install or update.
Command exited with code 1