### PR TITLE
Removed dependency on Microsoft.AspNetCore.Http.Extensions

### DIFF
--- a/NLog.Web.AspNetCore.Tests/LayoutRenderers/AspNetApplicationValueLayoutRendererTests.cs
+++ b/NLog.Web.AspNetCore.Tests/LayoutRenderers/AspNetApplicationValueLayoutRendererTests.cs
@@ -50,7 +50,7 @@ namespace NLog.Web.Tests.LayoutRenderers
             Assert.Empty(result);
         }
 
-        [Theory, MemberData("VariableFoundData")]
+        [Theory, MemberData(nameof(VariableFoundData))]
         public void VariableFoundRendersValue(object expectedValue)
         {
             var httpContext = Substitute.For<HttpContextBase>();

--- a/NLog.Web.AspNetCore.Tests/LayoutRenderers/AspNetItemValueLayoutRendererTests.cs
+++ b/NLog.Web.AspNetCore.Tests/LayoutRenderers/AspNetItemValueLayoutRendererTests.cs
@@ -63,6 +63,8 @@ namespace NLog.Web.Tests.LayoutRenderers
 			httpContext.Items = new Dictionary<object, object>();
 			httpContext.Items.Add("key", expectedValue);
 #else
+            httpContext.Items.Count.Returns(1);
+            httpContext.Items.Contains("key").Returns(true);
             httpContext.Items["key"].Returns(expectedValue);
 #endif
             var cultureInfo = new CultureInfo("nl-NL");
@@ -85,6 +87,8 @@ namespace NLog.Web.Tests.LayoutRenderers
             httpContext.Items = new Dictionary<object, object>();
             httpContext.Items.Add("key", expectedValue);
 #else
+            httpContext.Items.Count.Returns(1);
+            httpContext.Items.Contains("key").Returns(true);
             httpContext.Items["key"].Returns(expectedValue);
 #endif
 
@@ -101,7 +105,14 @@ namespace NLog.Web.Tests.LayoutRenderers
         public void NestedPropertyRendersValue(string itemKey, string variable, object data, object expectedValue)
         {
             var httpContext = Substitute.For<HttpContextBase>();
+#if ASP_NET_CORE
+            httpContext.Items = new Dictionary<object, object>();
+            httpContext.Items.Add(itemKey, data);
+#else
+            httpContext.Items.Count.Returns(1);
+            httpContext.Items.Contains(itemKey).Returns(true);
             httpContext.Items[itemKey].Returns(data);
+#endif
 
             var renderer = new AspNetItemValueLayoutRenderer();
             renderer.Variable = variable;

--- a/NLog.Web.AspNetCore.Tests/LayoutRenderers/AspNetRequestValueLayoutRendererTests.cs
+++ b/NLog.Web.AspNetCore.Tests/LayoutRenderers/AspNetRequestValueLayoutRendererTests.cs
@@ -48,7 +48,7 @@ namespace NLog.Web.Tests.LayoutRenderers
             string result = renderer.Render(new LogEventInfo());
 
             Assert.Empty(result);
-            Assert.Equal(true, string.IsNullOrEmpty(internalLog.ToString()));
+            Assert.True(string.IsNullOrEmpty(internalLog.ToString()));
         }
 
         public class ItemTests

--- a/NLog.Web.AspNetCore.Tests/LayoutRenderers/AspNetSessionValueLayoutRendererTests.cs
+++ b/NLog.Web.AspNetCore.Tests/LayoutRenderers/AspNetSessionValueLayoutRendererTests.cs
@@ -23,15 +23,12 @@ namespace NLog.Web.Tests.LayoutRenderers
 {
     public class AspNetSessionValueLayoutRendererTests : TestInvolvingAspNetHttpContext
     {
-
-
-
         public AspNetSessionValueLayoutRendererTests()
         {
             SetUp();
         }
 
-        public void SetUp()
+        private void SetUp()
         {
             //auto load won't work yet (in DNX), so use <extensions>
             LogManager.Configuration = CreateConfigurationFromString(@"
@@ -232,7 +229,7 @@ namespace NLog.Web.Tests.LayoutRenderers
         /// <summary>
         /// Create Fake Session http://stackoverflow.com/a/10126711/201303
         /// </summary>
-        public void SetupFakeSession()
+        private void SetupFakeSession()
         {
             var sessionContainer = new HttpSessionStateContainer("id", new SessionStateItemCollection(),
                                                     new HttpStaticObjectsCollection(), 10, true,

--- a/NLog.Web.AspNetCore/Internal/PropertyReader.cs
+++ b/NLog.Web.AspNetCore/Internal/PropertyReader.cs
@@ -11,27 +11,27 @@ namespace NLog.Web.Internal
         /// Get value of a property
         /// </summary>
         /// <param name="key">key</param>
+        /// <param name="container">Container to perform value lookup using key</param>
         /// <param name="getVal">function to get a value with this key</param>
         /// <param name="evaluateAsNestedProperties">evaluate <paramref name="key"/> as a nested property path. E.g. A.B is property B inside A.</param>
         /// <returns>value</returns>
-        public static object GetValue(string key, Func<string, object> getVal, bool evaluateAsNestedProperties)
+        public static object GetValue<T>(string key, T container, Func<T, string, object> getVal, bool evaluateAsNestedProperties)
         {
             if (String.IsNullOrEmpty(key))
             {
                 return null;
             }
 
-            var value = evaluateAsNestedProperties ? GetValueAsNestedProperties(key, getVal) : getVal(key);
+            var value = evaluateAsNestedProperties ? GetValueAsNestedProperties(key, container, getVal) : getVal(container, key);
             return value;
         }
 
-        private static object GetValueAsNestedProperties(string key, Func<string, object> getVal)
+        private static object GetValueAsNestedProperties<T>(string key, T container, Func<T, string, object> getVal)
         {
-            var path = key.Split(new[] {'.'}, StringSplitOptions.RemoveEmptyEntries);
+            var path = key.IndexOf('.') >= 0 ? key.Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries) : null;
 
-            var value = getVal(path.First());
-
-            if (value != null)
+            var value = getVal(container, path?.First() ?? key);
+            if (value != null && path?.Length > 1)
             {
                 foreach (var property in path.Skip(1))
                 {

--- a/NLog.Web.AspNetCore/Internal/RequestAccessorExtension.cs
+++ b/NLog.Web.AspNetCore/Internal/RequestAccessorExtension.cs
@@ -32,5 +32,21 @@ namespace NLog.Web.Internal
             return context.Request;
         }
 #endif
+
+#if ASP_NET_CORE
+        internal static string GetString(this ISession session, string key)
+        {
+            if (!session.TryGetValue(key, out var data))
+                return null;
+
+            if (data == null)
+                return null;
+
+            if (data.Length == 0)
+                return string.Empty;
+
+            return Encoding.UTF8.GetString(data);
+        }
+#endif
     }
 }

--- a/NLog.Web.AspNetCore/LayoutRenderers/AspNetItemValueLayoutRenderer.cs
+++ b/NLog.Web.AspNetCore/LayoutRenderers/AspNetItemValueLayoutRenderer.cs
@@ -82,20 +82,21 @@ namespace NLog.Web.LayoutRenderers
             }
 
             var context = HttpContextAccessor.HttpContext;
-#if !ASP_NET_CORE
-            Func<System.Collections.IDictionary, string, object> getVal = (items, key) => 
-            {
-                return items?.Count > 0 && items.Contains(key) ? items[key] : null;
-            };
-#else
-            Func<IDictionary<object, object>, string, object> getVal = (items, key) =>
-            {
-                return items != null && items.TryGetValue(key, out var itemValue) ? itemValue : null;
-            };
-#endif
-            var value = PropertyReader.GetValue(Variable, context?.Items, getVal, EvaluateAsNestedProperties);
+            var value = PropertyReader.GetValue(Variable, context?.Items, LookupItemValue, EvaluateAsNestedProperties);
             var formatProvider = GetFormatProvider(logEvent, Culture);
             builder.Append(Convert.ToString(value, formatProvider));
         }
+
+#if !ASP_NET_CORE
+        private static object LookupItemValue(System.Collections.IDictionary items, string key)
+        {
+            return items?.Count > 0 && items.Contains(key) ? items[key] : null;
+        }
+#else
+        private static object LookupItemValue(IDictionary<object, object> items, string key)
+        {
+            return items != null && items.TryGetValue(key, out var itemValue) ? itemValue : null;
+        }
+#endif
     }
 }

--- a/NLog.Web.AspNetCore/LayoutRenderers/AspNetLayoutRendererBase.cs
+++ b/NLog.Web.AspNetCore/LayoutRenderers/AspNetLayoutRendererBase.cs
@@ -40,6 +40,7 @@ namespace NLog.Web.LayoutRenderers
         /// Provides access to the current request HttpContext.
         /// </summary>
         /// <returns>HttpContextAccessor or <c>null</c></returns>
+        [NLog.Config.NLogConfigurationIgnorePropertyAttribute]
         public IHttpContextAccessor HttpContextAccessor
         {
             get => _httpContextAccessor ?? (_httpContextAccessor = RetrieveHttpContextAccessor());
@@ -72,9 +73,11 @@ namespace NLog.Web.LayoutRenderers
         }
 
 #else
+
         /// <summary>
         /// Provides access to the current request HttpContext.
         /// </summary>
+        [NLog.Config.NLogConfigurationIgnorePropertyAttribute]
         public IHttpContextAccessor HttpContextAccessor { get; set; }
 
 #endif

--- a/NLog.Web.AspNetCore/NLog.Web.AspNetCore.csproj
+++ b/NLog.Web.AspNetCore/NLog.Web.AspNetCore.csproj
@@ -82,14 +82,12 @@ Supported platforms:
 
   <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' and '$(TargetFramework)' != 'net461' ">
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="1.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="1.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="1.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="1.1.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net461' ">
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="2.0.0" />
   </ItemGroup>

--- a/NLog.Web.Tests/NLog.Web.Tests.csproj
+++ b/NLog.Web.Tests/NLog.Web.Tests.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NLog.Web.Tests</RootNamespace>
     <AssemblyName>NLog.Web.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -20,6 +20,7 @@
     <TestProjectType>UnitTest</TestProjectType>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -54,9 +55,6 @@
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Numerics" />
-    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
-    </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Transactions" />
@@ -65,21 +63,17 @@
     <Reference Include="System.Web.Routing" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+    <Reference Include="xunit.abstractions">
       <HintPath>..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="xunit.assert">
       <HintPath>..\packages\xunit.assert.2.3.1\lib\netstandard1.1\xunit.assert.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="xunit.core">
       <HintPath>..\packages\xunit.extensibility.core.2.3.1\lib\netstandard1.1\xunit.core.dll</HintPath>
-      <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.execution.dotnet">
-      <HintPath>..\packages\xunit.extensibility.execution.2.3.1\lib\netstandard1.1\xunit.execution.dotnet.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="xunit.execution.desktop">
+      <HintPath>..\packages\xunit.extensibility.execution.2.3.1\lib\net452\xunit.execution.desktop.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Choose>
@@ -151,7 +145,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props'))" />
     <Error Condition="!Exists('..\packages\xunit.core.2.3.1\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.3.1\build\xunit.core.props'))" />

--- a/NLog.Web.Tests/packages.NLog.Web.Tests.config
+++ b/NLog.Web.Tests/packages.NLog.Web.Tests.config
@@ -1,44 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net45" />
-  <package id="NETStandard.Library" version="1.6.1" targetFramework="net45" />
-  <package id="NLog" version="4.5.8" targetFramework="net45" />
-  <package id="NSubstitute" version="2.0.3" targetFramework="net45" />
-  <package id="System.Collections" version="4.3.0" targetFramework="net45" />
-  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net45" />
-  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net45" />
-  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net45" />
-  <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net45" />
-  <package id="System.Globalization" version="4.3.0" targetFramework="net45" />
-  <package id="System.IO" version="4.3.0" targetFramework="net45" />
-  <package id="System.IO.Compression" version="4.3.0" targetFramework="net45" />
-  <package id="System.Linq" version="4.3.0" targetFramework="net45" />
-  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net45" />
-  <package id="System.Net.Http" version="4.3.0" targetFramework="net45" />
-  <package id="System.Net.Primitives" version="4.3.0" targetFramework="net45" />
-  <package id="System.ObjectModel" version="4.3.0" targetFramework="net45" />
-  <package id="System.Reflection" version="4.3.0" targetFramework="net45" />
-  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net45" />
-  <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net45" />
-  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net45" />
-  <package id="System.Runtime" version="4.3.0" targetFramework="net45" />
-  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net45" />
-  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net45" />
-  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net45" />
-  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net45" />
-  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net45" />
-  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net45" />
-  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net45" />
-  <package id="System.Threading" version="4.3.0" targetFramework="net45" />
-  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net45" />
-  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net45" />
-  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net45" />
-  <package id="xunit" version="2.3.1" targetFramework="net45" />
-  <package id="xunit.abstractions" version="2.0.1" targetFramework="net45" />
-  <package id="xunit.analyzers" version="0.8.0" targetFramework="net45" />
-  <package id="xunit.assert" version="2.3.1" targetFramework="net45" />
-  <package id="xunit.core" version="2.3.1" targetFramework="net45" />
-  <package id="xunit.extensibility.core" version="2.3.1" targetFramework="net45" />
-  <package id="xunit.extensibility.execution" version="2.3.1" targetFramework="net45" />
-  <package id="xunit.runner.visualstudio" version="2.3.1" targetFramework="net45" developmentDependency="true" />
+  <package id="NLog" version="4.5.8" targetFramework="net452" />
+  <package id="NSubstitute" version="2.0.3" targetFramework="net452" />
+  <package id="xunit" version="2.3.1" targetFramework="net452" />
+  <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
+  <package id="xunit.analyzers" version="0.8.0" targetFramework="net452" />
+  <package id="xunit.assert" version="2.3.1" targetFramework="net452" />
+  <package id="xunit.core" version="2.3.1" targetFramework="net452" />
+  <package id="xunit.extensibility.core" version="2.3.1" targetFramework="net452" />
+  <package id="xunit.extensibility.execution" version="2.3.1" targetFramework="net452" />
+  <package id="xunit.runner.visualstudio" version="2.3.1" targetFramework="net452" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Could also be nice to remove "Microsoft.AspNetCore.Http", but it would require removal of `RegisterHttpContextAccessor`