### PR TITLE
${aspnet-request-querystring} and ${aspnet-request-cookie}): Make separators layoutable

### DIFF
--- a/NLog.Web.AspNetCore.Tests/LayoutRenderers/AspNetCookieLayoutRendererTests.cs
+++ b/NLog.Web.AspNetCore.Tests/LayoutRenderers/AspNetCookieLayoutRendererTests.cs
@@ -102,6 +102,29 @@ namespace NLog.Web.Tests.LayoutRenderers
         }
 
         [Fact]
+        public void KeyFoundRendersValue_Multiple_Cookies_Flat_Formatting_separators_layouts()
+        {
+            try
+            {
+                var expectedResult = "key>TEST" + Environment.NewLine + "Key1>TEST1";
+                GlobalDiagnosticsContext.Set("valueSeparator1", ">");
+
+                var renderer = CreateRenderer();
+                renderer.ValueSeparator = "${gdc:valueSeparator1}";
+                renderer.ItemSeparator = "${newline}";
+
+                string result = renderer.Render(new LogEventInfo());
+
+                Assert.Equal(expectedResult, result);
+            }
+            finally
+            {
+                //clean up
+                GlobalDiagnosticsContext.Clear();
+            }
+        }
+
+        [Fact]
         public void KeyFoundRendersValue_Single_Cookie_Flat_Formatting()
         {
             var expectedResult = "key=TEST";
@@ -272,7 +295,7 @@ namespace NLog.Web.Tests.LayoutRenderers
             Assert.Equal(expectedResult, result);
         }
 
-//no multivalue cookie keys in ASP.NET core
+        //no multivalue cookie keys in ASP.NET core
 #if !ASP_NET_CORE
 
         [Fact]
@@ -422,7 +445,7 @@ namespace NLog.Web.Tests.LayoutRenderers
                 cookies.Add(cookie2);
                 cookieNames.Add("Key1");
             }
-           
+
             if (addMultiValueCookieKey)
             {
                 var multiValueCookie = new HttpCookie("key2", "Test");

--- a/NLog.Web.AspNetCore.Tests/NLog.Web.AspNetCore.Tests.csproj
+++ b/NLog.Web.AspNetCore.Tests/NLog.Web.AspNetCore.Tests.csproj
@@ -45,4 +45,9 @@
   <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.Web">
+      <HintPath>C:\Windows\Microsoft.NET\Framework\v2.0.50727\System.Web.dll</HintPath>
+    </Reference>
+  </ItemGroup>
 </Project>

--- a/NLog.Web.AspNetCore/LayoutRenderers/AspNetRequestCookieLayoutRenderer.cs
+++ b/NLog.Web.AspNetCore/LayoutRenderers/AspNetRequestCookieLayoutRenderer.cs
@@ -47,7 +47,7 @@ namespace NLog.Web.LayoutRenderers
             if (CookieNames?.Count > 0 && cookies?.Count > 0)
             {
                 var cookieValues = GetCookies(cookies);
-                SerializePairs(cookieValues, builder);
+                SerializePairs(cookieValues, builder, logEvent);
             }
         }
 

--- a/NLog.Web.AspNetCore/LayoutRenderers/AspNetRequestQueryStringLayoutRenderer.cs
+++ b/NLog.Web.AspNetCore/LayoutRenderers/AspNetRequestQueryStringLayoutRenderer.cs
@@ -75,7 +75,7 @@ namespace NLog.Web.LayoutRenderers
 #endif
 
             var pairs = GetPairs(queryStrings, queryStringKeys);
-            SerializePairs(pairs, builder);
+            SerializePairs(pairs, builder, logEvent);
         }
 
         private static IEnumerable<KeyValuePair<string, string>> GetPairs(


### PR DESCRIPTION
Make ItemSeparator and ValueSeparator layoutable  for ${aspnet-request-querystring} and ${aspnet-request-cookie}