### PR TITLE
Added ThreadSafe-attribute for LayoutRenderer to optimize async Precalculate

### DIFF
--- a/NLog.Web.AspNetCore.Tests/LayoutRenderers/AspNetRequestValueLayoutRendererTests.cs
+++ b/NLog.Web.AspNetCore.Tests/LayoutRenderers/AspNetRequestValueLayoutRendererTests.cs
@@ -1,25 +1,24 @@
-﻿#if !ASP_NET_CORE
-//TODO test .NET Core
-using System.Collections.Specialized;
-using System.IO;
+﻿using System.IO;
 #if !ASP_NET_CORE
+using System.Collections.Specialized;
 using System.Web;
 using System.Web.Routing;
 using System.Web.SessionState;
 #else
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 using HttpContextBase = Microsoft.AspNetCore.Http.HttpContext;
 #endif
 using NLog.Common;
-using NLog.Config;
 using NLog.Web.LayoutRenderers;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
+using System.Collections.Generic;
 
 namespace NLog.Web.Tests.LayoutRenderers
 {
-    public class AspNetRequestValueLayoutRendererTests : TestBase
+    public class AspNetRequestValueLayoutRendererTests : TestInvolvingAspNetHttpContext
     {
         [Fact]
         public void NullHttpContextRendersEmptyString()
@@ -31,6 +30,7 @@ namespace NLog.Web.Tests.LayoutRenderers
             Assert.Empty(result);
         }
 
+#if !ASP_NET_CORE
         [Fact]
         public void NullRequestRendersEmptyStringWithoutLoggingError()
         {
@@ -50,6 +50,7 @@ namespace NLog.Web.Tests.LayoutRenderers
             Assert.Empty(result);
             Assert.True(string.IsNullOrEmpty(internalLog.ToString()));
         }
+#endif
 
         public class ItemTests
         {
@@ -86,7 +87,11 @@ namespace NLog.Web.Tests.LayoutRenderers
             {
                 var expectedResult = "value";
                 var httpContext = Substitute.For<HttpContextBase>();
+#if !ASP_NET_CORE
                 httpContext.Request["key"].Returns(expectedResult);
+#else
+                httpContext.Request.HttpContext.Items.Returns(new Dictionary<object, object>() { { "key", expectedResult } });
+#endif
 
                 var renderer = new AspNetRequestValueLayoutRenderer();
                 renderer.HttpContextAccessor = new FakeHttpContextAccessor(httpContext);
@@ -133,7 +138,12 @@ namespace NLog.Web.Tests.LayoutRenderers
             {
                 var expectedResult = "value";
                 var httpContext = Substitute.For<HttpContextBase>();
+#if !ASP_NET_CORE
                 httpContext.Request.QueryString.Returns(new NameValueCollection { {"key", expectedResult} });
+#else
+                var queryCollection = new Microsoft.AspNetCore.Http.Internal.QueryCollection(new Dictionary<string, StringValues>() { { "key", expectedResult } });
+                httpContext.Request.Query.Returns(queryCollection);
+#endif
 
                 var renderer = new AspNetRequestValueLayoutRenderer();
                 renderer.HttpContextAccessor = new FakeHttpContextAccessor(httpContext);
@@ -180,7 +190,12 @@ namespace NLog.Web.Tests.LayoutRenderers
             {
                 var expectedResult = "value";
                 var httpContext = Substitute.For<HttpContextBase>();
+#if !ASP_NET_CORE
                 httpContext.Request.Headers.Returns(new NameValueCollection { { "key", expectedResult } });
+#else
+                var headerDictionary = new HeaderDictionary(new Dictionary<string, StringValues>() { { "key", expectedResult } });
+                httpContext.Request.Headers.Returns(headerDictionary);
+#endif
 
                 var renderer = new AspNetRequestValueLayoutRenderer();
                 renderer.HttpContextAccessor = new FakeHttpContextAccessor(httpContext);
@@ -227,7 +242,13 @@ namespace NLog.Web.Tests.LayoutRenderers
             {
                 var expectedResult = "value";
                 var httpContext = Substitute.For<HttpContextBase>();
+#if !ASP_NET_CORE
                 httpContext.Request.Form.Returns(new NameValueCollection { { "key", expectedResult } });
+#else
+                httpContext.Request.HasFormContentType.Returns(true);
+                var formCollection = new FormCollection(new Dictionary<string, StringValues>{ { "key", expectedResult } });
+                httpContext.Request.Form.Returns(formCollection);
+#endif
 
                 var renderer = new AspNetRequestValueLayoutRenderer();
                 renderer.HttpContextAccessor = new FakeHttpContextAccessor(httpContext);
@@ -239,6 +260,7 @@ namespace NLog.Web.Tests.LayoutRenderers
             }
         }
 
+#if !ASP_NET_CORE
         public class ServerVariablesTests
         {
             [Fact]
@@ -285,7 +307,7 @@ namespace NLog.Web.Tests.LayoutRenderers
                 Assert.Equal(expectedResult, result);
             }
         }
-
+#endif
         public class CookieTests
         {
             [Fact]
@@ -321,7 +343,12 @@ namespace NLog.Web.Tests.LayoutRenderers
             {
                 var expectedResult = "value";
                 var httpContext = Substitute.For<HttpContextBase>();
+#if !ASP_NET_CORE
                 httpContext.Request.Cookies.Returns(new HttpCookieCollection {new HttpCookie("key", expectedResult) });
+#else
+                var cookieCollection = new Microsoft.AspNetCore.Http.Internal.RequestCookieCollection(new Dictionary<string, string>{ { "key", expectedResult } });
+                httpContext.Request.Cookies.Returns(cookieCollection);
+#endif
 
                 var renderer = new AspNetRequestValueLayoutRenderer();
                 renderer.HttpContextAccessor = new FakeHttpContextAccessor(httpContext);
@@ -334,4 +361,3 @@ namespace NLog.Web.Tests.LayoutRenderers
         }
     }
 }
-#endif

--- a/NLog.Web.AspNetCore/LayoutRenderers/AspNetAppBasePathLayoutRenderer.cs
+++ b/NLog.Web.AspNetCore/LayoutRenderers/AspNetAppBasePathLayoutRenderer.cs
@@ -7,6 +7,7 @@ using NLog.Web.DependencyInjection;
 #else
 using System.Web.Hosting;
 #endif
+using NLog.Config;
 using NLog.LayoutRenderers;
 
 namespace NLog.Web.LayoutRenderers
@@ -21,6 +22,8 @@ namespace NLog.Web.LayoutRenderers
     /// </summary>
 #endif
     [LayoutRenderer("aspnet-appbasepath")]
+    [ThreadAgnostic]
+    [ThreadSafe]
     public class AspNetAppBasePathLayoutRenderer : LayoutRenderer
     {
 #if ASP_NET_CORE

--- a/NLog.Web.AspNetCore/LayoutRenderers/AspNetApplicationValueLayoutRenderer.cs
+++ b/NLog.Web.AspNetCore/LayoutRenderers/AspNetApplicationValueLayoutRenderer.cs
@@ -35,6 +35,7 @@ namespace NLog.Web.LayoutRenderers
     /// </code>
     /// </example>
     [LayoutRenderer("aspnet-application")]
+    [ThreadSafe]
     public class AspNetApplicationValueLayoutRenderer : AspNetLayoutRendererBase
     {
         /// <summary>

--- a/NLog.Web.AspNetCore/LayoutRenderers/AspNetEnvironmentLayoutRenderer.cs
+++ b/NLog.Web.AspNetCore/LayoutRenderers/AspNetEnvironmentLayoutRenderer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Text;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
+using NLog.Config;
 using NLog.LayoutRenderers;
 using NLog.Web.DependencyInjection;
 
@@ -13,6 +14,8 @@ namespace NLog.Web.LayoutRenderers
     /// Rendering development environment. <see cref="IHostingEnvironment"/>
     /// </summary>
     [LayoutRenderer("aspnet-environment")]
+    [ThreadAgnostic]
+    [ThreadSafe]
     public class AspNetEnvironmentLayoutRenderer : LayoutRenderer
     {
         private static IHostingEnvironment _hostingEnvironment;

--- a/NLog.Web.AspNetCore/LayoutRenderers/AspNetItemValueLayoutRenderer.cs
+++ b/NLog.Web.AspNetCore/LayoutRenderers/AspNetItemValueLayoutRenderer.cs
@@ -40,6 +40,7 @@ namespace NLog.Web.LayoutRenderers
     /// </code>
     /// </example>
     [LayoutRenderer("aspnet-item")]
+    [ThreadSafe]
     public class AspNetItemValueLayoutRenderer : AspNetLayoutRendererBase
     {
         /// <summary>

--- a/NLog.Web.AspNetCore/LayoutRenderers/AspNetMvcActionRenderer.cs
+++ b/NLog.Web.AspNetCore/LayoutRenderers/AspNetMvcActionRenderer.cs
@@ -1,4 +1,3 @@
-using NLog.LayoutRenderers;
 using System.Text;
 #if !ASP_NET_CORE
 using System.Web.Routing;
@@ -8,6 +7,8 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Http;
 using HttpContextBase = Microsoft.AspNetCore.Http.HttpContext;
 #endif
+using NLog.Config;
+using NLog.LayoutRenderers;
 
 namespace NLog.Web.LayoutRenderers
 {
@@ -23,6 +24,7 @@ namespace NLog.Web.LayoutRenderers
     /// </code>
     /// </example>
     [LayoutRenderer("aspnet-mvc-action")]
+    [ThreadSafe]
     public class AspNetMvcActionRenderer : AspNetMvcLayoutRendererBase
     {
         /// <summary>

--- a/NLog.Web.AspNetCore/LayoutRenderers/AspNetMvcControllerRenderer.cs
+++ b/NLog.Web.AspNetCore/LayoutRenderers/AspNetMvcControllerRenderer.cs
@@ -1,4 +1,3 @@
-using NLog.LayoutRenderers;
 using System.Text;
 #if !ASP_NET_CORE
 using System.Web.Routing;
@@ -8,7 +7,8 @@ using HttpContextBase = Microsoft.AspNetCore.Http.HttpContext;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Http;
 #endif
-
+using NLog.Config;
+using NLog.LayoutRenderers;
 
 namespace NLog.Web.LayoutRenderers
 {
@@ -24,6 +24,7 @@ namespace NLog.Web.LayoutRenderers
     /// </code>
     /// </example>
     [LayoutRenderer("aspnet-mvc-controller")]
+    [ThreadSafe]
     public class AspNetMvcControllerRenderer : AspNetMvcLayoutRendererBase
     {
         /// <summary>

--- a/NLog.Web.AspNetCore/LayoutRenderers/AspNetRequestContentTypeLayoutRenderer.cs
+++ b/NLog.Web.AspNetCore/LayoutRenderers/AspNetRequestContentTypeLayoutRenderer.cs
@@ -1,5 +1,6 @@
 #if ASP_NET_CORE
 using System.Text;
+using NLog.Config;
 using NLog.LayoutRenderers;
 using NLog.Web.Internal;
 
@@ -14,6 +15,7 @@ namespace NLog.Web.LayoutRenderers
     /// </code>
     /// </example>
     [LayoutRenderer("aspnet-request-contenttype")]
+    [ThreadSafe]
     public class AspNetRequestContentTypeLayoutRenderer : AspNetLayoutRendererBase
     {
         /// <summary>

--- a/NLog.Web.AspNetCore/LayoutRenderers/AspNetRequestHostLayoutRenderer.cs
+++ b/NLog.Web.AspNetCore/LayoutRenderers/AspNetRequestHostLayoutRenderer.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using NLog.Config;
 using NLog.LayoutRenderers;
 using NLog.Web.Internal;
 
@@ -12,10 +13,11 @@ namespace NLog.Web.LayoutRenderers
     /// </remarks>
     /// <example>
     /// <code lang="NLog Layout Renderer">
-    /// ${aspnet-host}    
+    /// ${aspnet-request-host}    
     /// </code>
     /// </example>
     [LayoutRenderer("aspnet-request-host")]
+    [ThreadSafe]
     public class AspNetRequestHostLayoutRenderer : AspNetLayoutRendererBase
     {
         /// <summary>
@@ -30,17 +32,11 @@ namespace NLog.Web.LayoutRenderers
                 return;
 
 #if ASP_NET_CORE
-            var host = request.Host;
+            var host = request.Host.ToString();
 #else
-            var host = request.UserHostName;
+            var host = request.UserHostName?.ToString();
 #endif
-            if (host != null)
-            {
-                var hostString = host.ToString();
-
-                if (!string.IsNullOrEmpty(hostString))
-                    builder.Append(hostString);
-            }
+            builder.Append(host);
         }
     }
 }

--- a/NLog.Web.AspNetCore/LayoutRenderers/AspNetRequestHttpMethodRenderer.cs
+++ b/NLog.Web.AspNetCore/LayoutRenderers/AspNetRequestHttpMethodRenderer.cs
@@ -2,8 +2,8 @@
 using System.Text;
 #if !ASP_NET_CORE
 using System.Web;
-using System.Collections.Specialized;
 #endif
+using NLog.Config;
 using NLog.LayoutRenderers;
 using NLog.Web.Internal;
 
@@ -19,6 +19,7 @@ namespace NLog.Web.LayoutRenderers
     /// </code>
     /// </example>
     [LayoutRenderer("aspnet-request-method")]
+    [ThreadSafe]
     public class AspNetRequestHttpMethodRenderer : AspNetLayoutRendererBase
     {
         /// <summary>

--- a/NLog.Web.AspNetCore/LayoutRenderers/AspNetRequestIpLayoutRenderer.cs
+++ b/NLog.Web.AspNetCore/LayoutRenderers/AspNetRequestIpLayoutRenderer.cs
@@ -3,6 +3,7 @@ using System.Text;
 #if ASP_NET_CORE
 using Microsoft.AspNetCore.Http;
 #endif
+using NLog.Config;
 using NLog.LayoutRenderers;
 using NLog.Web.Internal;
 
@@ -17,6 +18,7 @@ namespace NLog.Web.LayoutRenderers
     /// </code>
     /// </example>
     [LayoutRenderer("aspnet-request-ip")]
+    [ThreadSafe]
     public class AspNetRequestIpLayoutRenderer : AspNetLayoutRendererBase
     {
         private const string ForwardedForHeader = "X-Forwarded-For";
@@ -73,10 +75,9 @@ namespace NLog.Web.LayoutRenderers
 #else
         string TryLookupForwardHeader(HttpRequest httpRequest)
         {
-            if (httpRequest.Headers.ContainsKey(ForwardedForHeader))
+            if (httpRequest.Headers?.ContainsKey(ForwardedForHeader)==true)
             {
                 var forwardedHeaders = httpRequest.Headers.GetCommaSeparatedValues(ForwardedForHeader);
-
                 if (forwardedHeaders.Length > 0)
                 {
                     return forwardedHeaders[0];

--- a/NLog.Web.AspNetCore/LayoutRenderers/AspNetRequestReferrerRenderer.cs
+++ b/NLog.Web.AspNetCore/LayoutRenderers/AspNetRequestReferrerRenderer.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Web;
 using System.Collections.Specialized;
 #endif
+using NLog.Config;
 using NLog.LayoutRenderers;
 using NLog.Web.Internal;
 
@@ -19,6 +20,7 @@ namespace NLog.Web.LayoutRenderers
     /// </code>
     /// </example>
     [LayoutRenderer("aspnet-request-referrer")]
+    [ThreadSafe]
     public class AspNetRequestReferrerRenderer : AspNetLayoutRendererBase
     {
         /// <summary>

--- a/NLog.Web.AspNetCore/LayoutRenderers/AspNetRequestUrlRenderer.cs
+++ b/NLog.Web.AspNetCore/LayoutRenderers/AspNetRequestUrlRenderer.cs
@@ -3,8 +3,8 @@ using System.Text;
 #if !ASP_NET_CORE
 using System.Collections.Specialized;
 using System.Web;
-#else
 #endif
+using NLog.Config;
 using NLog.LayoutRenderers;
 using NLog.Web.Internal;
 
@@ -25,6 +25,7 @@ namespace NLog.Web.LayoutRenderers
     /// </code>
     /// </example>
     [LayoutRenderer("aspnet-request-url")]
+    [ThreadSafe]
     public class AspNetRequestUrlRenderer : AspNetLayoutRendererBase
     {
         /// <summary>
@@ -42,7 +43,6 @@ namespace NLog.Web.LayoutRenderers
         /// </summary>
         public bool IncludeHost { get; set; } = true;
 
-
         /// <summary>
         /// To specify whether to exclude / include the scheme. Default is true.
         /// </summary>
@@ -59,71 +59,59 @@ namespace NLog.Web.LayoutRenderers
             if (httpRequest == null)
                 return;
 
-            var url = CreateUrl(httpRequest);
-            builder.Append(url);
+            RenderUrl(httpRequest, builder);
         }
 
 #if !ASP_NET_CORE
-
-        private string CreateUrl(HttpRequestBase httpRequest)
+        private void RenderUrl(HttpRequestBase httpRequest, StringBuilder builder)
         {
-            string port = null, host = null, scheme = null;
+            var url =  httpRequest.Url;
+            if (url == null)
+                return;
 
-            if (httpRequest.Url == null)
+            if (IncludeScheme && !string.IsNullOrEmpty(url.Scheme))
             {
-                return null;
+                builder.Append(url.Scheme);
+                builder.Append("://");
             }
-
-            if (IncludePort && httpRequest.Url.Port > 0)
-            {
-                port = ":" + httpRequest.Url.Port;
-            }
-
-            var pathAndQuery = IncludeQueryString ? httpRequest.Url.PathAndQuery : httpRequest.Url.AbsolutePath;
-
             if (IncludeHost)
             {
-                host = httpRequest.Url?.Host;
+                builder.Append(url.Host);
             }
-
-            if (IncludeScheme)
+            if (IncludePort && url.Port > 0)
             {
-                scheme = httpRequest.Url.Scheme + "://";
+                builder.Append(':');
+                builder.Append(url.Port);
             }
 
-            var url = $"{scheme}{host}{port}{pathAndQuery}";
-            return url;
+            var pathAndQuery = IncludeQueryString ? url.PathAndQuery : url.AbsolutePath;
+            builder.Append(pathAndQuery);
         }
-
 #else
-        private string CreateUrl(Microsoft.AspNetCore.Http.HttpRequest httpRequest)
+        private void RenderUrl(Microsoft.AspNetCore.Http.HttpRequest httpRequest, StringBuilder builder)
         {
-            string pathAndQuery = null, port = null, host = null, scheme = null;
-        
-            if (IncludeQueryString)
+            if (IncludeScheme && !string.IsNullOrWhiteSpace(httpRequest.Scheme))
             {
-                pathAndQuery = httpRequest.QueryString.Value;
+                builder.Append(httpRequest.Scheme);
+                builder.Append("://");
             }
-
+            if (IncludeHost)
+            {
+                builder.Append(httpRequest.Host.Host);
+            }
             if (IncludePort && httpRequest.Host.Port > 0)
             {
-                port = ":" + httpRequest.Host.Port.ToString();
+                builder.Append(':');
+                builder.Append(httpRequest.Host.Port.Value);
             }
 
-            if (IncludeHost)
+            builder.Append(httpRequest.PathBase.ToUriComponent());
+            builder.Append(httpRequest.Path.ToUriComponent());
+            if (IncludeQueryString)
             {
-                host = httpRequest.Host.Host;
+                builder.Append(httpRequest.QueryString.Value);
             }
-
-            if (IncludeScheme && !String.IsNullOrWhiteSpace(httpRequest.Scheme))
-            {
-                scheme = httpRequest.Scheme + "://";
-            }
-
-            var url = $"{scheme}{host}{port}{httpRequest.PathBase.ToUriComponent()}{httpRequest.Path.ToUriComponent()}{pathAndQuery}";
-            return url;
         }
-
 #endif
     }
 }

--- a/NLog.Web.AspNetCore/LayoutRenderers/AspNetRequestuseragent.cs
+++ b/NLog.Web.AspNetCore/LayoutRenderers/AspNetRequestuseragent.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Collections.Specialized;
 using System.Web;
 #endif
+using NLog.Config;
 using NLog.LayoutRenderers;
 using NLog.Web.Internal;
 
@@ -19,6 +20,7 @@ namespace NLog.Web.LayoutRenderers
     /// </code>
     /// </example>
     [LayoutRenderer("aspnet-request-useragent")]
+    [ThreadSafe]
     public class AspNetRequestUserAgent : AspNetLayoutRendererBase
     {
         /// <summary>

--- a/NLog.Web.AspNetCore/LayoutRenderers/AspNetSessionIdLayoutRenderer.cs
+++ b/NLog.Web.AspNetCore/LayoutRenderers/AspNetSessionIdLayoutRenderer.cs
@@ -1,9 +1,8 @@
 using System.Text;
 #if !ASP_NET_CORE
 using System.Web;
-#else
-
 #endif
+using NLog.Config;
 using NLog.LayoutRenderers;
 
 namespace NLog.Web.LayoutRenderers
@@ -12,6 +11,7 @@ namespace NLog.Web.LayoutRenderers
     /// ASP.NET Session ID.
     /// </summary>
     [LayoutRenderer("aspnet-sessionid")]
+    [ThreadSafe]
     public class AspNetSessionIdLayoutRenderer : AspNetLayoutRendererBase
     {
         /// <summary>

--- a/NLog.Web.AspNetCore/LayoutRenderers/AspNetSessionValueLayoutRenderer.cs
+++ b/NLog.Web.AspNetCore/LayoutRenderers/AspNetSessionValueLayoutRenderer.cs
@@ -42,6 +42,7 @@ namespace NLog.Web.LayoutRenderers
     /// </code>
     /// </example>
     [LayoutRenderer("aspnet-session")]
+    [ThreadSafe]
     public class AspNetSessionValueLayoutRenderer : AspNetLayoutRendererBase
     {
         /// <summary>
@@ -111,9 +112,11 @@ namespace NLog.Web.LayoutRenderers
                 context.Items.Remove(NLogRetrievingSessionValue);
             }
 #endif
-
-            var formatProvider = GetFormatProvider(logEvent, Culture);
-            builder.Append(Convert.ToString(value, formatProvider));
+            if (value != null)
+            {
+                var formatProvider = GetFormatProvider(logEvent, Culture);
+                builder.Append(Convert.ToString(value, formatProvider));
+            }
         }
 
 #if ASP_NET_CORE

--- a/NLog.Web.AspNetCore/LayoutRenderers/AspNetTraceIdentifierLayoutRenderer.cs
+++ b/NLog.Web.AspNetCore/LayoutRenderers/AspNetTraceIdentifierLayoutRenderer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text;
+using NLog.Config;
 using NLog.LayoutRenderers;
 
 namespace NLog.Web.LayoutRenderers
@@ -9,6 +10,7 @@ namespace NLog.Web.LayoutRenderers
     /// </summary>
     /// <remarks>.NET Core Only</remarks>
     [LayoutRenderer("aspnet-traceidentifier")]
+    [ThreadSafe]
     public class AspNetTraceIdentifierLayoutRenderer : AspNetLayoutRendererBase
     {
         /// <inheritdoc />

--- a/NLog.Web.AspNetCore/LayoutRenderers/AspNetUserAuthTypeLayoutRenderer.cs
+++ b/NLog.Web.AspNetCore/LayoutRenderers/AspNetUserAuthTypeLayoutRenderer.cs
@@ -2,8 +2,8 @@ using System;
 using System.Text;
 #if !ASP_NET_CORE
 using System.Web;
-#else
 #endif
+using NLog.Config;
 using NLog.LayoutRenderers;
 
 namespace NLog.Web.LayoutRenderers
@@ -12,6 +12,7 @@ namespace NLog.Web.LayoutRenderers
     /// ASP.NET User variable.
     /// </summary>
     [LayoutRenderer("aspnet-user-authtype")]
+    [ThreadSafe]
     public class AspNetUserAuthTypeLayoutRenderer : AspNetLayoutRendererBase
     {
         /// <summary>

--- a/NLog.Web.AspNetCore/LayoutRenderers/AspNetUserIdentityLayoutRenderer.cs
+++ b/NLog.Web.AspNetCore/LayoutRenderers/AspNetUserIdentityLayoutRenderer.cs
@@ -2,8 +2,8 @@ using System;
 using System.Text;
 #if !ASP_NET_CORE
 using System.Web;
-#else
 #endif
+using NLog.Config;
 using NLog.LayoutRenderers;
 
 namespace NLog.Web.LayoutRenderers
@@ -12,6 +12,7 @@ namespace NLog.Web.LayoutRenderers
     /// ASP.NET User variable.
     /// </summary>
     [LayoutRenderer("aspnet-user-identity")]
+    [ThreadSafe]
     public class AspNetUserIdentityLayoutRenderer : AspNetLayoutRendererBase
     {
         /// <summary>

--- a/NLog.Web.AspNetCore/LayoutRenderers/AspNetUserIsAuthenticatedLayoutRenderer.cs
+++ b/NLog.Web.AspNetCore/LayoutRenderers/AspNetUserIsAuthenticatedLayoutRenderer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text;
+using NLog.Config;
 using NLog.LayoutRenderers;
 using NLog.Web.LayoutRenderers;
 
@@ -11,6 +12,7 @@ namespace NLog.Web.AspNetCore.LayoutRenderers
     /// ${aspnet-user-isAuthenticated}
     /// </summary>
     [LayoutRenderer("aspnet-user-isAuthenticated")]
+    [ThreadSafe]
     public class AspNetUserIsAuthenticatedLayoutRenderer : AspNetLayoutRendererBase
     {
         /// <summary>

--- a/NLog.Web.AspNetCore/LayoutRenderers/AspNetWebRootPathLayoutRenderer.cs
+++ b/NLog.Web.AspNetCore/LayoutRenderers/AspNetWebRootPathLayoutRenderer.cs
@@ -7,6 +7,7 @@ using NLog.Web.DependencyInjection;
 #else
 using System.Web.Hosting;
 #endif
+using NLog.Config;
 using NLog.LayoutRenderers;
 
 namespace NLog.Web.LayoutRenderers
@@ -21,6 +22,8 @@ namespace NLog.Web.LayoutRenderers
     /// </summary>
 #endif
     [LayoutRenderer("aspnet-webrootpath")]
+    [ThreadAgnostic]
+    [ThreadSafe]
     public class AspNetWebRootPathLayoutRenderer : LayoutRenderer
     {
 #if ASP_NET_CORE

--- a/NLog.Web.AspNetCore/LayoutRenderers/AssemblyVersionLayoutRenderer.cs
+++ b/NLog.Web.AspNetCore/LayoutRenderers/AssemblyVersionLayoutRenderer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using NLog.Common;
+using NLog.Config;
 using NLog.LayoutRenderers;
 
 namespace NLog.Web.LayoutRenderers
@@ -11,6 +12,8 @@ namespace NLog.Web.LayoutRenderers
     /// Extend NLog.LayoutRenderers.AssemblyVersionLayoutRenderer with ASP.NET Full and Core support
     /// </summary>
     [LayoutRenderer("assembly-version")]
+    [ThreadAgnostic]
+    [ThreadSafe]
     public class AssemblyVersionLayoutRenderer : NLog.LayoutRenderers.AssemblyVersionLayoutRenderer
     {
         /// <inheritdoc />

--- a/NLog.Web.AspNetCore/LayoutRenderers/IISInstanceNameLayoutRenderer.cs
+++ b/NLog.Web.AspNetCore/LayoutRenderers/IISInstanceNameLayoutRenderer.cs
@@ -7,6 +7,7 @@ using NLog.Web.DependencyInjection;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 #endif
+using NLog.Config;
 using NLog.LayoutRenderers;
 
 namespace NLog.Web.LayoutRenderers
@@ -23,6 +24,8 @@ namespace NLog.Web.LayoutRenderers
 #endif
     [LayoutRenderer("iis-site-name")]
     // ReSharper disable once InconsistentNaming
+    [ThreadAgnostic]
+    [ThreadSafe]
     public class IISInstanceNameLayoutRenderer : LayoutRenderer
     {
 #if ASP_NET_CORE


### PR DESCRIPTION
When using AsyncWrapper then logger-threads will be able to precalculate-layouts concurrently without waiting for Target-lock.

- ${aspnet-request-url} now renders directly to StringBuilder
- ${aspnet-request} now also checks HasFormContentType. See also #322 (Also enabled unit tests for NetCore)
