### PR TITLE
aspnet-traceidentifier: Support for ASP.NET (non-core) - requires IIS ETW

### DIFF
--- a/NLog.Web.AspNetCore.Tests/LayoutRenderers/AspNetRequestFormLayoutRendererTests.cs
+++ b/NLog.Web.AspNetCore.Tests/LayoutRenderers/AspNetRequestFormLayoutRendererTests.cs
@@ -1,17 +1,17 @@
-﻿using NLog.Web.Tests.LayoutRenderers;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Text;
-using NLog.Web.LayoutRenderers;
-using NLog.Web.Tests;
-using NSubstitute;
 using System.Collections.Specialized;
+using System.Text;
 #if ASP_NET_CORE
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 #else
 using System.Web;
 #endif
+using NLog.Web.LayoutRenderers;
+using NLog.Web.Tests;
+using NLog.Web.Tests.LayoutRenderers;
+using NSubstitute;
 using Xunit;
 
 namespace NLog.Web.Tests.LayoutRenderers

--- a/NLog.Web.AspNetCore/LayoutRenderers/AspNetTraceIdentifierLayoutRenderer.cs
+++ b/NLog.Web.AspNetCore/LayoutRenderers/AspNetTraceIdentifierLayoutRenderer.cs
@@ -17,7 +17,38 @@ namespace NLog.Web.LayoutRenderers
         protected override void DoAppend(StringBuilder builder, LogEventInfo logEvent)
         {
             var httpContext = HttpContextAccessor.HttpContext;
-            builder.Append(httpContext.TraceIdentifier);
+            builder.Append(LookupTraceIdentifier(httpContext));
         }
+
+#if ASP_NET_CORE
+        private string LookupTraceIdentifier(Microsoft.AspNetCore.Http.HttpContext httpContext)
+        {
+            return httpContext.TraceIdentifier;
+        }
+#else
+        /// <summary>
+        /// Requires IIS ETW feature enabled. https://docs.microsoft.com/en-us/iis/configuration/system.webServer/httpTracing/
+        ///
+        /// See also http://blog.tatham.oddie.com.au/2012/02/07/code-request-correlation-in-asp-net/
+        /// </summary>
+        private string LookupTraceIdentifier(System.Web.HttpContextBase httpContext)
+        {
+            IServiceProvider serviceProvider = httpContext;
+            if (serviceProvider != null)
+            {
+                var workerRequest = (System.Web.HttpWorkerRequest)serviceProvider.GetService(typeof(System.Web.HttpWorkerRequest));
+                if (workerRequest != null)
+                {
+                    Guid requestIdGuid = workerRequest.RequestTraceIdentifier;
+                    if (requestIdGuid != Guid.Empty)
+                    {
+                        return requestIdGuid.ToString();
+                    }
+                }
+            }
+
+            return null;
+        }
+#endif
     }
 }

--- a/NLog.Web.AspNetCore/LayoutRenderers/AspNetTraceIdentifierLayoutRenderer.cs
+++ b/NLog.Web.AspNetCore/LayoutRenderers/AspNetTraceIdentifierLayoutRenderer.cs
@@ -6,9 +6,8 @@ using NLog.LayoutRenderers;
 namespace NLog.Web.LayoutRenderers
 {
     /// <summary>
-    /// Print the TraceIdentifier
+    /// ASP.NET Request TraceIdentifier.
     /// </summary>
-    /// <remarks>.NET Core Only</remarks>
     [LayoutRenderer("aspnet-traceidentifier")]
     [ThreadSafe]
     public class AspNetTraceIdentifierLayoutRenderer : AspNetLayoutRendererBase

--- a/NLog.Web.Tests/NLog.Web.Tests.csproj
+++ b/NLog.Web.Tests/NLog.Web.Tests.csproj
@@ -101,6 +101,9 @@
     <Compile Include="..\NLog.Web.AspNetCore.Tests\LayoutRenderers\AspNetRequestValueLayoutRendererTests.cs" />
     <Compile Include="..\NLog.Web.AspNetCore.Tests\LayoutRenderers\AspNetSessionIDLayoutRendererTests.cs" />
     <Compile Include="..\NLog.Web.AspNetCore.Tests\LayoutRenderers\AspNetSessionValueLayoutRendererTests.cs" />
+    <Compile Include="..\NLog.Web.AspNetCore.Tests\LayoutRenderers\AspNetTraceIdentifierRendererTests.cs">
+      <Link>AspNetTraceIdentifierRendererTests.cs</Link>
+    </Compile>
     <Compile Include="..\NLog.Web.AspNetCore.Tests\LayoutRenderers\AspNetUserAuthTypeLayoutRendererTests.cs" />
     <Compile Include="..\NLog.Web.AspNetCore.Tests\LayoutRenderers\TestInvolvingAspNetHttpContext.cs" />
     <Compile Include="..\NLog.Web.AspNetCore.Tests\LayoutRenderers\AspNetUserIdentityLayoutRendererTests.cs" />

--- a/NLog.Web/NLog.Web.csproj
+++ b/NLog.Web/NLog.Web.csproj
@@ -75,6 +75,9 @@
     <Compile Include="..\NLog.Web.AspNetCore\LayoutRenderers\AspNetRequestIpLayoutRenderer.cs" />
     <Compile Include="..\NLog.Web.AspNetCore\LayoutRenderers\AspNetSessionIdLayoutRenderer.cs" />
     <Compile Include="..\NLog.Web.AspNetCore\LayoutRenderers\AspNetSessionValueLayoutRenderer.cs" />
+    <Compile Include="..\NLog.Web.AspNetCore\LayoutRenderers\AspNetTraceIdentifierLayoutRenderer.cs">
+      <Link>AspNetTraceIdentifierLayoutRenderer.cs</Link>
+    </Compile>
     <Compile Include="..\NLog.Web.AspNetCore\LayoutRenderers\AspNetUserAuthTypeLayoutRenderer.cs" />
     <Compile Include="..\NLog.Web.AspNetCore\LayoutRenderers\AspNetUserIdentityLayoutRenderer.cs" />
     <Compile Include="..\NLog.Web.AspNetCore\LayoutRenderers\AspNetWebRootPathLayoutRenderer.cs" />


### PR DESCRIPTION
Attempt to resolve #328 

Extracted from [HttpWorkerRequest.RequestTraceIdentifier](https://docs.microsoft.com/dotnet/api/system.web.httpworkerrequest.requesttraceidentifier). Requires IIS ETW feature enabled: https://docs.microsoft.com/en-us/iis/configuration/system.webServer/httpTracing/ (IIS7 - Win2008)