### PR TITLE
Updated ASP.NET Core 2 example to netcoreapp2.1

### DIFF
--- a/examples/ASP.NET Core 2/Visual Studio 2017/ASP.NET Core 2 - VS2017/ASP.NET Core 2 - VS2017.csproj
+++ b/examples/ASP.NET Core 2/Visual Studio 2017/ASP.NET Core 2 - VS2017/ASP.NET Core 2 - VS2017.csproj
@@ -1,7 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetLatestAspNetCoreRuntimePatch>true</TargetLatestAspNetCoreRuntimePatch>
+    <RuntimeFrameworkVersion>2.1.*</RuntimeFrameworkVersion>
     <AssemblyName>NLog.Web.AspNetCore2.Example</AssemblyName>
     <RootNamespace>NLog.Web.AspNetCore2.Example</RootNamespace>
     <FileVersion>1.0.0.1</FileVersion>
@@ -9,11 +11,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
+    <Folder Include="wwwroot\" />
   </ItemGroup>
-
+  
   <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/ASP.NET Core 2/Visual Studio 2017/ASP.NET Core 2 - VS2017/Program.cs
+++ b/examples/ASP.NET Core 2/Visual Studio 2017/ASP.NET Core 2 - VS2017/Program.cs
@@ -15,7 +15,7 @@ namespace NLog.Web.AspNetCore2.Example
             try
             {
                 logger.Debug("init main");
-                BuildWebHost(args).Run();
+                BuildWebHost(args).Build().Run();
             }
             catch (Exception exception)
             {
@@ -30,7 +30,7 @@ namespace NLog.Web.AspNetCore2.Example
             }
         }
 
-        public static IWebHost BuildWebHost(string[] args) =>
+        public static IWebHostBuilder BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
                 .ConfigureLogging(logging =>
@@ -38,7 +38,6 @@ namespace NLog.Web.AspNetCore2.Example
                     logging.ClearProviders();
                     logging.SetMinimumLevel(Microsoft.Extensions.Logging.LogLevel.Trace);
                 })
-                .UseNLog()  // NLog: Setup NLog for Dependency injection
-                .Build();
+                .UseNLog();  // NLog: Setup NLog for Dependency injection
     }
 }

--- a/examples/ASP.NET Core 2/Visual Studio 2017/ASP.NET Core 2 - VS2017/Startup.cs
+++ b/examples/ASP.NET Core 2/Visual Studio 2017/ASP.NET Core 2 - VS2017/Startup.cs
@@ -29,7 +29,6 @@ namespace NLog.Web.AspNetCore2.Example
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
-                app.UseBrowserLink();
             }
             else
             {


### PR DESCRIPTION
Resolves #329 

Also updated Wiki: https://github.com/NLog/NLog.Web/wiki/Getting-started-with-ASP.NET-Core-2 (NetCore2 became obsolete October 2018)