### PR TITLE
 AspNetRequestPostedBody - Check ContentLength before using Body   + Added MaxContentLength (default 30Kib) + update build script

### DIFF
--- a/NLog.Web.AspNetCore.Tests/LayoutRenderers/AspNetRequestPostedBodyTests.cs
+++ b/NLog.Web.AspNetCore.Tests/LayoutRenderers/AspNetRequestPostedBodyTests.cs
@@ -55,6 +55,40 @@ namespace NLog.Web.AspNetCore.Tests.LayoutRenderers
             Assert.Equal(position, stream.Position);
         }
 
+        [Theory]
+        [InlineData("", null, "")]
+        [InlineData("", 0, "")]
+        [InlineData("ABCDEFGHIJK", null, "ABCDEFGHIJK")]
+        [InlineData("ABCDEFGHIJK", 0, "ABCDEFGHIJK")]
+        [InlineData("ABCDEFGHIJK", 50, "ABCDEFGHIJK")]
+        [InlineData("ABCDEFGHIJK", 10, "")]
+        public void MaxContentLengthProtectsAgainstLargeBodyStreamTest(string body, int? maxContentLength, string expectedResult)
+        {
+            MaxContentLengthProtectsAgainstLargeBodyStream(body, maxContentLength, expectedResult, false);
+#if ASP_NET_CORE
+            MaxContentLengthProtectsAgainstLargeBodyStream(body, maxContentLength, expectedResult, true);
+#endif
+        }
+
+        private static void MaxContentLengthProtectsAgainstLargeBodyStream(string body, int? maxContentLength, string expectedResult, bool canReadOnce)
+        {
+            // Arrange
+            var (renderer, httpContext) = CreateWithHttpContext();
+            if (maxContentLength.HasValue)
+                renderer.MaxContentLength = maxContentLength.Value;
+
+            var stream = CreateStream(body, canReadOnce);
+            SetBodyStream(httpContext, stream);
+
+            var logEventInfo = new LogEventInfo();
+
+            // Act
+            string result = renderer.Render(logEventInfo);
+
+            // Assert
+            Assert.Equal(expectedResult, result);
+        }
+
         private static void SetBodyStream(HttpContextBase httpContext, Stream stream)
         {
 #if ASP_NET_CORE
@@ -65,13 +99,20 @@ namespace NLog.Web.AspNetCore.Tests.LayoutRenderers
             httpContext.Request.ContentLength.Returns((int)(stream?.Length ?? 0));
         }
 
-        private static MemoryStream CreateStream(string content)
+        private static MemoryStream CreateStream(string content, bool readOnce = false)
         {
-            var stream = new MemoryStream();
+            var stream = readOnce ? new ReadOnceStream() : new MemoryStream();
             var streamWriter = new StreamWriter(stream);
             streamWriter.Write(content);
             streamWriter.Flush();
+            if (readOnce)
+                stream.Position = 0;
             return stream;
+        }
+
+        class ReadOnceStream : MemoryStream
+        {
+            public override bool CanSeek => false;
         }
     }
 }

--- a/NLog.Web.AspNetCore.Tests/LayoutRenderers/AspNetRequestPostedBodyTests.cs
+++ b/NLog.Web.AspNetCore.Tests/LayoutRenderers/AspNetRequestPostedBodyTests.cs
@@ -2,10 +2,11 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
-using System.Web;
 #if ASP_NET_CORE
 using Microsoft.AspNetCore.Http;
 using HttpContextBase = Microsoft.AspNetCore.Http.HttpContext;
+#else
+using System.Web;
 #endif
 using NLog.Web.LayoutRenderers;
 using NLog.Web.Tests.LayoutRenderers;

--- a/NLog.Web.AspNetCore.Tests/LayoutRenderers/AspNetRequestPostedBodyTests.cs
+++ b/NLog.Web.AspNetCore.Tests/LayoutRenderers/AspNetRequestPostedBodyTests.cs
@@ -62,6 +62,7 @@ namespace NLog.Web.AspNetCore.Tests.LayoutRenderers
 #else
             httpContext.Request.InputStream.Returns(stream);
 #endif
+            httpContext.Request.ContentLength.Returns((int)(stream?.Length ?? 0));
         }
 
         private static MemoryStream CreateStream(string content)

--- a/NLog.Web.AspNetCore.Tests/LayoutRenderers/LayoutRenderersTestBase.cs
+++ b/NLog.Web.AspNetCore.Tests/LayoutRenderers/LayoutRenderersTestBase.cs
@@ -1,5 +1,4 @@
-﻿using System.Web;
-using NLog.Web.LayoutRenderers;
+﻿using NLog.Web.LayoutRenderers;
 using NLog.Web.Tests;
 using NSubstitute;
 using Xunit;
@@ -7,6 +6,8 @@ using Xunit;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Routing;
 using HttpContextBase = Microsoft.AspNetCore.Http.HttpContext;
+#else
+using System.Web;
 #endif
 
 namespace NLog.Web.Tests.LayoutRenderers

--- a/NLog.Web.AspNetCore.Tests/NLog.Web.AspNetCore.Tests.csproj
+++ b/NLog.Web.AspNetCore.Tests/NLog.Web.AspNetCore.Tests.csproj
@@ -20,9 +20,6 @@
   <ItemGroup>
     <ProjectReference Include="..\NLog.Web.AspNetCore\NLog.Web.AspNetCore.csproj" />
     <PackageReference Include="NSubstitute" Version="4.0.0" />
-    
-    <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
-    
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
@@ -40,10 +37,5 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="System.Web">
-      <HintPath>C:\Windows\Microsoft.NET\Framework\v2.0.50727\System.Web.dll</HintPath>
-    </Reference>
   </ItemGroup>
 </Project>

--- a/NLog.Web.AspNetCore/AspNetExtensions.cs
+++ b/NLog.Web.AspNetCore/AspNetExtensions.cs
@@ -178,7 +178,7 @@ namespace NLog.Web
             //note: this one is called before  services.AddSingleton<ILoggerFactory>
             if ((options ?? NLogAspNetCoreOptions.Default).RegisterHttpContextAccessor)
             {
-                services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+                services.AddHttpContextAccessor();
             }
         }
 #endif

--- a/NLog.Web.AspNetCore/LayoutRenderers/AspNetRequestPostedBody.cs
+++ b/NLog.Web.AspNetCore/LayoutRenderers/AspNetRequestPostedBody.cs
@@ -28,12 +28,15 @@ namespace NLog.Web.LayoutRenderers
     [ThreadSafe]
     public class AspNetRequestPostedBody : AspNetLayoutRendererBase
     {
+        private const int Size64KiloBytes = 64 * 1024;
+        private const int Size30Kilobytes = 30 * 1024;
+
         /// <summary>
         /// Max size in bytes of the body. Skip logging of the body when larger.
         /// Default 30720 Bytes = 30 KiB 
         /// (0 = No limit, -1 = No Buffer Limit)
         /// </summary>
-        public int MaxContentLength { get; set; } = 30 * 1024;
+        public int MaxContentLength { get; set; } = Size30Kilobytes;
 
         /// <summary>
         /// Renders the ASP.NET posted body
@@ -48,66 +51,18 @@ namespace NLog.Web.LayoutRenderers
                 return;
             }
 
-            long? contentLength = httpRequest.ContentLength;
-            if (contentLength <= 0)
+            if (!TryGetBody(httpRequest, out var body))
             {
                 return; // No Body to read
             }
 
-            if (MaxContentLength > 0 && contentLength > MaxContentLength)
-            {
-                InternalLogger.Debug("AspNetRequestPostedBody: body stream is too big. ContentLength={0}", contentLength);
-                return; // Body too large
-            }
-
-#if !ASP_NET_CORE
-            var body = httpRequest.InputStream;
-#else
-            var body = httpRequest.Body;
-#endif
-
-            if (body == null)
-            {
-                InternalLogger.Debug("AspNetRequestPostedBody: body stream was null");
-                return;
-            }
-
-            if (!body.CanRead)
-            {
-                InternalLogger.Debug("AspNetRequestPostedBody: body stream has been closed");
-                return;
-            }
-
             // reset if possible
-            long oldPosition = body.Position;
-            if (!body.CanSeek)
+            if (!TryResetStream(httpRequest, body, out var oldPosition))
             {
-                if (oldPosition > 0 && oldPosition >= contentLength)
-                {
-                    InternalLogger.Debug("AspNetRequestPostedBody: body stream cannot seek and already read. StreamPosition={0}", oldPosition);
-                    return;
-                }
-
-                oldPosition = 0;
-                if (!TryEnableBuffering(httpRequest, contentLength, out body))
-                {
-                    return; // Body cannot be buffered
-                }
-            }
-            else
-            {
-                if (MaxContentLength > 0 && !contentLength.HasValue && body.Length > MaxContentLength)
-                {
-                    InternalLogger.Debug("AspNetRequestPostedBody: body stream too big. Body.Length={0}", body.Length);
-                    return; // Body too large
-                }
+                return;
             }
 
-            body.Position = 0;
-
-            //note: dispose of StreamReader isn't doing things besides closing the stream (which can be turn off, and then it's a NOOP)
-            var bodyReader = new StreamReader(body);
-            var content = bodyReader.ReadToEnd();
+            var content = BodyToString(body);
 
             //restore
             body.Position = oldPosition;
@@ -115,34 +70,127 @@ namespace NLog.Web.LayoutRenderers
             builder.Append(content);
         }
 
-        bool TryEnableBuffering(HttpRequest httpRequest, long? contentLength, out Stream bodyStream)
+        private static string BodyToString(Stream body)
         {
-            bodyStream = null;
+            // Note: don't dispose the StreamReader, it will close the stream and that's unwanted. You could pass that that
+            // to the StreamReader in some platforms, but then the dispose will be a NOOP, so for platform compat just don't dispose
+            var bodyReader = new StreamReader(body);
+            var content = bodyReader.ReadToEnd();
+            return content;
+        }
 
+        private bool TryResetStream(HttpRequest httpRequest, Stream body, out long oldPosition)
+        {
+            long? contentLength = httpRequest.ContentLength;
+            oldPosition = body.Position;
+            if (!body.CanSeek)
+            {
+
+#if !ASP_NET_CORE
+                InternalLogger.Debug("AspNetRequestPostedBody: body stream cannot seek");
+                return false;
+#endif
+
+
+                if (oldPosition > 0 && oldPosition >= contentLength)
+                {
+                    InternalLogger.Debug("AspNetRequestPostedBody: body stream cannot seek and already read. StreamPosition={0}", oldPosition);
+                    return false;
+                }
+
+                oldPosition = 0;
+                if (!TryEnableRewind(httpRequest))
+                {
+                    return false;
+                }
+
+                // can seek after buffering?
+                if (!body.CanSeek)
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                if (MaxContentLength > 0 && !contentLength.HasValue && body.Length > MaxContentLength)
+                {
+                    InternalLogger.Debug("AspNetRequestPostedBody: body stream too big. Body.Length={0}", body.Length);
+                    return false;
+                }
+            }
+
+            body.Position = 0;
+            return true;
+        }
+
+        private bool TryGetBody(HttpRequest httpRequest, out Stream body)
+        {
+            long? contentLength = httpRequest.ContentLength;
+            body = null;
+            if (contentLength <= 0)
+            {
+                return false;
+            }
+
+            if (MaxContentLength > 0 && contentLength > MaxContentLength)
+            {
+                InternalLogger.Debug("AspNetRequestPostedBody: body stream is too big. ContentLength={0}", contentLength);
+                return false;
+            }
+
+            body = GetBodyStream(httpRequest);
+
+            if (body == null)
+            {
+                InternalLogger.Debug("AspNetRequestPostedBody: body stream was null");
+                return false;
+            }
+
+            if (!body.CanRead)
+            {
+                InternalLogger.Debug("AspNetRequestPostedBody: body stream has been closed");
+                return false;
+            }
+
+            return true;
+        }
+
+        private static Stream GetBodyStream(HttpRequest httpRequest)
+        {
+#if !ASP_NET_CORE
+            var body = httpRequest.InputStream;
+#else
+            var body = httpRequest.Body;
+#endif
+            return body;
+        }
+
+        private bool TryEnableRewind(HttpRequest httpRequest)
+        {
+            long? contentLength = httpRequest.ContentLength;
             if (MaxContentLength >= 0 && !contentLength.HasValue)
             {
                 InternalLogger.Debug("AspNetRequestPostedBody: body stream cannot seek with unknown ContentLength");
                 return false;
             }
 
-            int bufferThreshold = MaxContentLength <= 0 ? 64 * 1024 : MaxContentLength;
+            int bufferThreshold = MaxContentLength <= 0 ? Size64KiloBytes : MaxContentLength;
             if (MaxContentLength == 0 && contentLength > bufferThreshold)
             {
                 InternalLogger.Debug("AspNetRequestPostedBody: body stream cannot seek and stream is too big. ContentLength={0}", contentLength);
                 return false;
             }
 
+            EnableRewind(httpRequest, bufferThreshold);
+            return true;
+        }
+
+        private static void EnableRewind(HttpRequest httpRequest, int bufferThreshold)
+        {
 #if ASP_NET_CORE2
             Microsoft.AspNetCore.Http.HttpRequestRewindExtensions.EnableBuffering(httpRequest, bufferThreshold);
-            bodyStream = httpRequest.Body;
-            return bodyStream?.CanSeek == true;
 #elif ASP_NET_CORE1
             Microsoft.AspNetCore.Http.Internal.BufferingHelper.EnableRewind(httpRequest, bufferThreshold);
-            bodyStream = httpRequest.Body;
-            return bodyStream?.CanSeek == true;
-#else
-            InternalLogger.Debug("AspNetRequestPostedBody: body stream cannot seek");
-            return false;
 #endif
         }
     }

--- a/NLog.Web.AspNetCore/LayoutRenderers/AspNetRequestPostedBody.cs
+++ b/NLog.Web.AspNetCore/LayoutRenderers/AspNetRequestPostedBody.cs
@@ -38,6 +38,11 @@ namespace NLog.Web.LayoutRenderers
                 return;
             }
 
+            if (httpRequest.ContentLength <= 0)
+            {
+                return; // No Body to read
+            }
+
 #if !ASP_NET_CORE
             var body = httpRequest.InputStream;
 #else
@@ -47,6 +52,12 @@ namespace NLog.Web.LayoutRenderers
             if (body == null)
             {
                 InternalLogger.Debug("AspNetRequestPostedBody: body stream was null");
+                return;
+            }
+
+            if (!body.CanRead)
+            {
+                InternalLogger.Debug("AspNetRequestPostedBody: body stream has been closed");
                 return;
             }
 

--- a/NLog.Web.AspNetCore/LayoutRenderers/AspNetRequestPostedBody.cs
+++ b/NLog.Web.AspNetCore/LayoutRenderers/AspNetRequestPostedBody.cs
@@ -29,7 +29,9 @@ namespace NLog.Web.LayoutRenderers
     public class AspNetRequestPostedBody : AspNetLayoutRendererBase
     {
         /// <summary>
-        /// Skip logging of HttpRequest.Body when ContentLength is larger than this (0 = No limit, -1 = No Buffer Limit)
+        /// Max size in bytes of the body. Skip logging of the body when larger.
+        /// Default 30720 Bytes = 30 KiB 
+        /// (0 = No limit, -1 = No Buffer Limit)
         /// </summary>
         public int MaxContentLength { get; set; } = 30 * 1024;
 

--- a/NLog.Web.AspNetCore/LayoutRenderers/AspNetRequestPostedBody.cs
+++ b/NLog.Web.AspNetCore/LayoutRenderers/AspNetRequestPostedBody.cs
@@ -8,6 +8,9 @@ using NLog.Web.Internal;
 
 #if !ASP_NET_CORE
 using System.Web;
+using HttpRequest = System.Web.HttpRequestBase;
+#else
+using HttpRequest = Microsoft.AspNetCore.Http.HttpRequest;
 #endif
 
 namespace NLog.Web.LayoutRenderers
@@ -26,6 +29,11 @@ namespace NLog.Web.LayoutRenderers
     public class AspNetRequestPostedBody : AspNetLayoutRendererBase
     {
         /// <summary>
+        /// Skip logging of HttpRequest.Body when ContentLength is larger than this (0 = No limit, -1 = No Buffer Limit)
+        /// </summary>
+        public int MaxContentLength { get; set; } = 30 * 1024;
+
+        /// <summary>
         /// Renders the ASP.NET posted body
         /// </summary>
         /// <param name="builder">The <see cref="StringBuilder" /> to append the rendered data to.</param>
@@ -38,9 +46,16 @@ namespace NLog.Web.LayoutRenderers
                 return;
             }
 
-            if (httpRequest.ContentLength <= 0)
+            long? contentLength = httpRequest.ContentLength;
+            if (contentLength <= 0)
             {
                 return; // No Body to read
+            }
+
+            if (MaxContentLength > 0 && contentLength > MaxContentLength)
+            {
+                InternalLogger.Debug("AspNetRequestPostedBody: body stream is too big. ContentLength={0}", contentLength);
+                return; // Body too large
             }
 
 #if !ASP_NET_CORE
@@ -61,26 +76,72 @@ namespace NLog.Web.LayoutRenderers
                 return;
             }
 
-            long oldPosition = -1;
-
             // reset if possible
-            if (body.CanSeek)
+            long oldPosition = body.Position;
+            if (!body.CanSeek)
             {
-                oldPosition = body.Position;
-                body.Position = 0;
+                if (oldPosition > 0 && oldPosition >= contentLength)
+                {
+                    InternalLogger.Debug("AspNetRequestPostedBody: body stream cannot seek and already read. StreamPosition={0}", oldPosition);
+                    return;
+                }
+
+                oldPosition = 0;
+                if (!TryEnableBuffering(httpRequest, contentLength, out body))
+                {
+                    return; // Body cannot be buffered
+                }
             }
+            else
+            {
+                if (MaxContentLength > 0 && !contentLength.HasValue && body.Length > MaxContentLength)
+                {
+                    InternalLogger.Debug("AspNetRequestPostedBody: body stream too big. Body.Length={0}", body.Length);
+                    return; // Body too large
+                }
+            }
+
+            body.Position = 0;
 
             //note: dispose of StreamReader isn't doing things besides closing the stream (which can be turn off, and then it's a NOOP)
             var bodyReader = new StreamReader(body);
             var content = bodyReader.ReadToEnd();
 
             //restore
-            if (body.CanSeek)
-            {
-                body.Position = oldPosition;
-            }
+            body.Position = oldPosition;
 
             builder.Append(content);
+        }
+
+        bool TryEnableBuffering(HttpRequest httpRequest, long? contentLength, out Stream bodyStream)
+        {
+            bodyStream = null;
+
+            if (MaxContentLength >= 0 && !contentLength.HasValue)
+            {
+                InternalLogger.Debug("AspNetRequestPostedBody: body stream cannot seek with unknown ContentLength");
+                return false;
+            }
+
+            int bufferThreshold = MaxContentLength <= 0 ? 64 * 1024 : MaxContentLength;
+            if (MaxContentLength == 0 && contentLength > bufferThreshold)
+            {
+                InternalLogger.Debug("AspNetRequestPostedBody: body stream cannot seek and stream is too big. ContentLength={0}", contentLength);
+                return false;
+            }
+
+#if ASP_NET_CORE2
+            Microsoft.AspNetCore.Http.HttpRequestRewindExtensions.EnableBuffering(httpRequest, bufferThreshold);
+            bodyStream = httpRequest.Body;
+            return bodyStream?.CanSeek == true;
+#elif ASP_NET_CORE1
+            Microsoft.AspNetCore.Http.Internal.BufferingHelper.EnableRewind(httpRequest, bufferThreshold);
+            bodyStream = httpRequest.Body;
+            return bodyStream?.CanSeek == true;
+#else
+            InternalLogger.Debug("AspNetRequestPostedBody: body stream cannot seek");
+            return false;
+#endif
         }
     }
 }

--- a/NLog.Web.AspNetCore/NLog.Web.AspNetCore.csproj
+++ b/NLog.Web.AspNetCore/NLog.Web.AspNetCore.csproj
@@ -5,14 +5,7 @@
 
     <TargetFrameworks>netstandard1.5;net451;net461;netstandard2.0</TargetFrameworks>
 
-    <VersionPrefix>4.8.1</VersionPrefix>
-    <VersionSuffix></VersionSuffix>
-    <Version>$(VersionPrefix)$(VersionSuffix)</Version>
-    <InformationalVersion>$(Version)</InformationalVersion>
-    <FileVersion>$(VersionPrefix).0</FileVersion>
-    <FileVersion Condition="'$(APPVEYOR_BUILD_NUMBER)' != ''">$(VersionPrefix).$(APPVEYOR_BUILD_NUMBER)</FileVersion>
-
-    <Product>NLog.Web.AspNetCore v$(Version)</Product>
+    <Product>NLog.Web.AspNetCore v$(VersionPrefix)</Product>
     <Description>
 Use NLog with the ASP.NET Core platform. Adds helpers and layout renderers for websites and webapplications.
 
@@ -37,7 +30,6 @@ Supported platforms:
     <PackageLicenseUrl>https://github.com/NLog/NLog.Web/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/NLog/NLog.Web</RepositoryUrl>
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 
     <SignAssembly>true</SignAssembly>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,7 +55,8 @@ deploy:
     branch: master
 test_script:
   - nuget.exe install OpenCover -ExcludeVersion -DependencyVersion Ignore
-  - OpenCover\tools\OpenCover.Console.exe -register:user -target:"%xunit20%\xunit.console.x86.exe" -targetargs:"\"c:\projects\nlogweb\NLog.Web.Tests\bin\Release\NLog.Web.Tests.dll\" -appveyor -noshadow"  -returntargetcode -filter:"+[NLog.Web]*" -excludebyattribute:*.ExcludeFromCodeCoverage* -hideskipped:All -output:coverage.xml
+  - OpenCover\tools\OpenCover.Console.exe -register:user -target:"%xunit20%\xunit.console.x86.exe" -targetargs:"\"c:\projects\nlogweb\NLog.Web.Tests\bin\Release\NLog.Web.Tests.dll\" -appveyor -noshadow"  -returntargetcode -filter:"+[NLog.Web]*" -excludebyattribute:*.ExcludeFromCodeCoverage* -hideskipped:All -oldstyle -output:coverage.xml
+  - OpenCover\tools\OpenCover.Console.exe -register:user -mergeoutput -target:"%xunit20%\xunit.console.x86.exe" -targetargs:"\"c:\projects\nlogweb\NLog.Web.AspNetCore.Tests\bin\Release\net461\NLog.Web.AspNetCore.Tests.dll\" -appveyor -noshadow" -filter:"+[NLog.Web]*" -excludebyattribute:*.ExcludeFromCodeCoverage* -hideskipped:All -oldstyle -output:coverage.xml
   - pip install codecov
   - codecov -f "coverage.xml"
   - ps: .\test_aspnetcore.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,8 +7,8 @@ assembly_info:
   patch: true
   file: '**\AssemblyInfo.cs'
   assembly_version: '4.0.0'
-  assembly_file_version: '4.8.1.{build}' #NLog.Web
-  assembly_informational_version: '4.8.1' #NLog.Web
+  assembly_file_version: '{version}' #NLog.Web
+  assembly_informational_version: '{version}' #NLog.Web
 nuget:
   project_feed: true
 matrix:
@@ -24,10 +24,27 @@ environment:
 skip_tags: true
 
 build_script:
-- cmd: >-
-    call build_aspnet.bat -nuget_version=4.8.1 # NLog.Web package
-
-    call build_aspnetcore.bat # update NLog.Web.AspNetCore.csproj for version number
+- ps: |
+    $versionPrefix = "4.8.1"
+    $versionSuffix = ""
+    $versionBuild = $versionPrefix + "." + ${env:APPVEYOR_BUILD_NUMBER}
+    $versionNuget = $versionPrefix
+    if ($env:APPVEYOR_PULL_REQUEST_NUMBER)
+    {
+        $versionPrefix = $versionBuild
+        $versionSuffix = "PR" + $env:APPVEYOR_PULL_REQUEST_NUMBER
+        $versionNuget = $versionPrefix + "-" + $versionSuffix
+    }
+    $build_aspnet = "build_aspnet.bat", "-nuget_version=$versionNuget"
+    & cmd /c $build_aspnet
+    if ($LastExitCode -ne 0) {
+        throw "Exec: $ErrorMessage"
+    }
+    $build_aspnetcore = "build_aspnetcore.bat", "-version_prefix=$versionPrefix", "-version_suffix=$versionSuffix", "-version_build=$versionBuild"
+    & cmd /c $build_aspnetcore
+    if ($LastExitCode -ne 0) {
+        throw "Exec: $ErrorMessage"
+    }
 
 deploy:
 - provider: NuGet

--- a/build_aspnet.bat
+++ b/build_aspnet.bat
@@ -1,14 +1,17 @@
-echo off
+@echo off
 
 rem fallback if not passed
-set nuget_version=2.2.0
+set nuget_version=1.0.0
 
 call :read_params %*
 
 nuget restore NLog.Web.sln -verbosity quiet
 msbuild NLog.Web.sln /verbosity:minimal /t:rebuild /p:configuration=release
+IF ERRORLEVEL 1 EXIT /B 1
 nuget pack NLog.Web\NLog.Web.csproj -properties Configuration=Release;Platform=AnyCPU -version %nuget_version%
+IF ERRORLEVEL 1 EXIT /B 1
 nuget pack NLog.Web\NLog.Web.csproj -properties Configuration=Release;Platform=AnyCPU -version %nuget_version% -symbols
+IF ERRORLEVEL 1 EXIT /B 1
 
 rem read pass parameters by name
 :read_params

--- a/build_aspnetcore.bat
+++ b/build_aspnetcore.bat
@@ -1,7 +1,28 @@
-echo off
+@echo off
 
-rem update NLog.Web.AspNetCore.csproj for version number
+rem fallback if not passed
+set version_prefix=1.0.0
+set version_suffix=
+set version_build=%version_prefix%
 
-cd NLog.Web.AspNetCore
-msbuild /t:restore /t:build /p:configuration=release /verbosity:minimal /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg
-cd ..
+call :read_params %*
+
+msbuild .\NLog.Web.AspNetCore /t:restore,pack /p:configuration=release /verbosity:minimal /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg /p:VersionPrefix=%version_prefix% /p:FileVersion=%version_build% /p:VersionSuffix=%version_suffix%
+IF ERRORLEVEL 1 EXIT /B 1
+
+rem read pass parameters by name
+:read_params
+if not %1/==/ (
+    if not "%__var%"=="" (
+        if not "%__var:~0,1%"=="-" (
+            endlocal
+            goto read_params
+        )
+        endlocal & set %__var:~1%=%~1
+    ) else (
+        setlocal & set __var=%~1
+    )
+    shift
+    goto read_params
+)
+exit /B


### PR DESCRIPTION
Trying to resolve `A non-empty request body is required.`  where NLog reads the body before it actually have been processed. (Making it impossible for AspNetCore-engine to read the Body-payload afterwards).

See also #399 and https://github.com/NLog/NLog/issues/3273

I guess the documentation should be updated about it can give an overhead when running on AspNetCore, because it by default is not buffering HttpRequest-Body. Adding this to the logging output will give a performance-penalty in extra allocations (`EnableRewind` / `EnableBuffering`).

Also if wanting to be completely sure that HttpRequest-Body can be logged, then it is probably recommended that the AspNetCore-application itself ensures that  (`EnableRewind` / `EnableBuffering`) is performed at the right time (before the Body has been completely read without the ability to read it again for logging).