### PR TITLE
Removed obsolete-attribute from ConfigureNLog-methods for ILoggingBuilder

### DIFF
--- a/src/NLog.Web.AspNetCore/AspNetExtensions.cs
+++ b/src/NLog.Web.AspNetCore/AspNetExtensions.cs
@@ -80,11 +80,9 @@ namespace NLog.Web
         /// <param name="configFileName">Path to NLog configuration file, e.g. nlog.config. </param>
         /// >
         /// <returns>LogFactory to get loggers, add events etc</returns>
-        [Obsolete("Use UseNLog() on IWebHostBuilder, and NLog.Web.NLogBuilder.ConfigureNLog()")]
         public static LogFactory ConfigureNLog(this ILoggingBuilder builder, string configFileName)
         {
-            ConfigurationItemFactory.Default.RegisterItemsFromAssembly(typeof(AspNetExtensions).GetTypeInfo().Assembly);
-            builder.AddNLog();
+            ConfigureServicesNLog(null, builder.Services, serviceProvider => serviceProvider.GetService<IConfiguration>());
             return LogManager.LoadConfiguration(configFileName);
         }
 
@@ -96,11 +94,9 @@ namespace NLog.Web
         /// <param name="builder">The logging builder</param>
         /// <param name="configuration">Config for NLog</param>
         /// <returns>LogFactory to get loggers, add events etc</returns>
-        [Obsolete("Use UseNLog() on IWebHostBuilder, and NLog.Web.NLogBuilder.ConfigureNLog()")]
         public static LogFactory ConfigureNLog(this ILoggingBuilder builder, LoggingConfiguration configuration)
         {
-            ConfigurationItemFactory.Default.RegisterItemsFromAssembly(typeof(AspNetExtensions).GetTypeInfo().Assembly);
-            builder.AddNLog();
+            ConfigureServicesNLog(null, builder.Services, serviceProvider => serviceProvider.GetService<IConfiguration>());
             LogManager.Configuration = configuration;
             return LogManager.LogFactory;
         }


### PR DESCRIPTION
Reverting #257. Since it will no longer generate double logging after #459 

Also fixed `ILoggingBuilder.ConfigureNLog()`-methods so they can work alone without `IHostBuilder.UseNLog()`.

See also: https://github.com/aspnet/AspNetCore.Docs/issues/14554