### PR TITLE
Updated dependencies to NET Core ver. 2.1 vanilla

### DIFF
--- a/src/NLog.Web.AspNetCore/NLog.Web.AspNetCore.csproj
+++ b/src/NLog.Web.AspNetCore/NLog.Web.AspNetCore.csproj
@@ -61,7 +61,7 @@ Supported platforms:
     <DefineConstants>$(DefineConstants);ASP_NET_CORE;ASP_NET_CORE3</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NLog.Extensions.Logging" Version="1.6.0" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="1.6.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <Reference Include="System" />
@@ -73,10 +73,10 @@ Supported platforms:
     <PackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="1.1.2" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net461' ">
-    <!-- Fixed to 2.1.1 as 2.1 is Long Term Supported (LTS) -->
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="2.1.1" />
+    <!-- Fixed to 2.1.0 as 2.1 is Long Term Supported (LTS) and works with vanilla .NET Core 2.1 SDK -->
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="2.1.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />


### PR DESCRIPTION
See also:

```
NU1607: Version conflict detected for Microsoft.AspNetCore.Hosting.Abstractions. Reference the package directly from the project to resolve this issue.
MyWebAPIProject (>= 1.0.0) -> NLog.Web.AspNetCore (>= 4.8.6) -> Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1)
 MyWebAPIProject (>= 1.0.0) -> Microsoft.AspNetCore.App (>= 2.1.0) -> Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.0).
```

From: https://stackoverflow.com/questions/58722743/how-to-fix-msbuild-error-nu1607-version-conflict-detected