### PR TITLE
aspnet-traceidentifier should automatically check Activity.Current.Id for AspNetCore3

### DIFF
--- a/src/Shared/LayoutRenderers/AspNetTraceIdentifierLayoutRenderer.cs
+++ b/src/Shared/LayoutRenderers/AspNetTraceIdentifierLayoutRenderer.cs
@@ -4,7 +4,6 @@ using NLog.Config;
 using NLog.LayoutRenderers;
 #if ASP_NET_CORE
 using Microsoft.AspNetCore.Http;
-
 #endif
 
 namespace NLog.Web.LayoutRenderers
@@ -23,7 +22,20 @@ namespace NLog.Web.LayoutRenderers
             builder.Append(LookupTraceIdentifier(httpContext));
         }
 
-#if ASP_NET_CORE
+        /// <summary>
+        /// Ignore the System.Diagnostics.Activity.Current.Id value (AspNetCore3 uses ActivityId by default)
+        /// </summary>
+        public bool IgnoreActivityId { get; set; }
+
+#if ASP_NET_CORE3
+        private string LookupTraceIdentifier(HttpContext httpContext)
+        {
+            if (IgnoreActivityId)
+                return httpContext.TraceIdentifier;
+            else
+                return System.Diagnostics.Activity.Current?.Id ?? httpContext.TraceIdentifier;
+        }
+#elif ASP_NET_CORE
         private string LookupTraceIdentifier(HttpContext httpContext)
         {
             return httpContext.TraceIdentifier;

--- a/tests/Shared/LayoutRenderers/AspNetTraceIdentifierRendererTests.cs
+++ b/tests/Shared/LayoutRenderers/AspNetTraceIdentifierRendererTests.cs
@@ -44,6 +44,26 @@ namespace NLog.Web.Tests.LayoutRenderers
             Assert.Equal(expectedResult.ToString(), result);
         }
 
+#if ASP_NET_CORE3
+        [Fact]
+        public void AvailableActivityIdOverridesGuid()
+        {
+            // Arrange
+            var (renderer, httpContext) = CreateWithHttpContext();
+
+            var expectedResult = System.Guid.NewGuid();
+            SetTraceIdentifier(httpContext, expectedResult);
+
+            System.Diagnostics.Activity.Current = new System.Diagnostics.Activity("MyOperation").Start();
+            
+            // Act
+            string result = renderer.Render(new LogEventInfo());
+
+            // Assert
+            Assert.Equal(System.Diagnostics.Activity.Current.Id, result);
+        }
+#endif
+
         private static void SetTraceIdentifier(HttpContextBase httpContext, Guid? expectedResult)
         {
 #if ASP_NET_CORE


### PR DESCRIPTION
This is what's used in ASP .NET Core 3 templates showing Request Id. Should do the same for consistency.

Resolves #523

See also: https://github.com/dotnet/aspnetcore/blob/2e4274cb67c049055e321c18cc9e64562da52dcf/src/Mvc/Mvc.Core/src/Infrastructure/DefaultProblemDetailsFactory.cs#L90