### PR TITLE
NLog.AspNetCore ver. 4.9.1

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,6 +4,10 @@ See also [releases](https://github.com/NLog/NLog.Web/releases) and [milestones](
 
 Date format: (year/month/day)
 
+### v4.9.1-aspnetcore (2020/03/25)
+- [#524](https://github.com/NLog/NLog.Web/pull/524) ${aspnet-traceidentifier} should automatically check Activity.Current.Id for NetCore3 (@snakefoot)
+- [#527](https://github.com/NLog/NLog.Web/pull/527) Improved AddNLog with LoggingConfiguration to handle custom LogFactory (@snakefoot)
+
 ### v4.9.0-aspnetcore (2019/10/11)
 This version adds support for ASP.NET Core 3 and some nice renderers has been added and improved!
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The packages contain
 targets and layout-renderes specific to ASP.NET (Core), MVC and IIS. 
 
 
-- [![Version](https://badge.fury.io/nu/NLog.Web.AspNetCore.svg)](https://www.nuget.org/packages/NLog.Web.AspNetCore)  (ASP.NET Core 1+2)
+- [![Version](https://badge.fury.io/nu/NLog.Web.AspNetCore.svg)](https://www.nuget.org/packages/NLog.Web.AspNetCore)  (ASP.NET Core)
 - [![Version](https://badge.fury.io/nu/NLog.Web.svg)](https://www.nuget.org/packages/NLog.Web) (ASP.NET)
 
 ## Getting started
@@ -26,7 +26,14 @@ targets and layout-renderes specific to ASP.NET (Core), MVC and IIS.
 
 For updates and releases, check [CHANGELOG.MD](CHANGELOG.MD) or [Releases](https://github.com/NLog/NLog.Web/releases)
 
-## ASP.NET Core 1 / ASP.NET Core 2
+## ASP.NET Core
+ASP.NET Core 1, 2 and 3 are supported!
+
+Supported platforms:
+
+- For ASP.NET Core 3, .NET Core 3.0
+- For ASP.NET Core 2, .NET Standard 2.0+ and .NET 4.6+
+- For ASP.NET Core 1, .NET Standard 1.5+ and .NET 4.5.x
 
 ℹ️  Missing the trace and debug logs in .NET Core 2? [Check your appsettings.json](https://github.com/NLog/NLog.Web/wiki/Missing-trace%5Cdebug-logs-in-ASP.NET-Core-2%3F)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![NLog](https://raw.githubusercontent.com/NLog/NLog.github.io/master/images/NLog-logo-only_small.png)
 
 # NLog.Web (ASP.NET & ASP.NET Core) 
-[![AppVeyor](https://img.shields.io/appveyor/ci/nlog/nlog-web/master.svg)](https://ci.appveyor.com/project/nlog/nlog-web/branch/master) [![codecov.io](https://codecov.io/github/NLog/NLog.Web/coverage.svg?branch=master)](https://codecov.io/github/NLog/NLog.Web?branch=master) [![BCH compliance](https://bettercodehub.com/edge/badge/NLog/NLog.Web)](https://bettercodehub.com/results/NLog/NLog.Web)
+[![AppVeyor](https://img.shields.io/appveyor/ci/nlog/nlog-web/master.svg)](https://ci.appveyor.com/project/nlog/nlog-web/branch/master) [![BCH compliance](https://bettercodehub.com/edge/badge/NLog/NLog.Web)](https://bettercodehub.com/results/NLog/NLog.Web)
 
 These packages are extensions to [NLog](https://github.com/NLog/NLog/). 
 

--- a/src/NLog.Web.AspNetCore/AspNetExtensions.cs
+++ b/src/NLog.Web.AspNetCore/AspNetExtensions.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Reflection;
-using Microsoft.AspNetCore.Http;
 using NLog.Config;
-using NLog.Extensions.Logging;
 using NLog.Web.DependencyInjection;
 #if ASP_NET_CORE1 || ASP_NET_CORE2
 using Microsoft.AspNetCore.Builder;
@@ -16,6 +14,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
+using NLog.Extensions.Logging;
 #endif
 
 namespace NLog.Web
@@ -61,7 +60,7 @@ namespace NLog.Web
 
         /// <summary>
         /// Override the default <see cref="IServiceProvider" /> used by the NLog ServiceLocator.
-        /// NLog ServiceLocator uses the <see cref="IServiceProvider" /> to access context specific services (Ex. <see cref="IHttpContextAccessor" />)
+        /// NLog ServiceLocator uses the <see cref="IServiceProvider" /> to access context specific services (Ex. <see cref="Microsoft.AspNetCore.Http.IHttpContextAccessor" />)
         /// </summary>
         /// <remarks>
         /// Should only be used if the standard approach for configuring NLog is not enough

--- a/src/NLog.Web.AspNetCore/AspNetExtensions.cs
+++ b/src/NLog.Web.AspNetCore/AspNetExtensions.cs
@@ -134,11 +134,23 @@ namespace NLog.Web
         /// <param name="configuration">Config for NLog</param>
         public static ILoggingBuilder AddNLog(this ILoggingBuilder builder, LoggingConfiguration configuration)
         {
-            AddNLogLoggerProvider(builder.Services, null, null, (serviceProvider, config, options) =>
+            return AddNLog(builder, configuration, null);
+        }
+
+        /// <summary>
+        /// Configure NLog from API
+        /// </summary>
+        /// <param name="builder">The logging builder</param>
+        /// <param name="configuration">Config for NLog</param>
+        /// <param name="options">Options for logging to NLog with Dependency Injected loggers</param>
+        public static ILoggingBuilder AddNLog(this ILoggingBuilder builder, LoggingConfiguration configuration, NLogAspNetCoreOptions options)
+        {
+            AddNLogLoggerProvider(builder.Services, null, options, (serviceProvider, config, opt) =>
             {
-                var provider = CreateNLogLoggerProvider(serviceProvider, config, options);
+                var logFactory = configuration?.LogFactory ?? LogManager.LogFactory;
+                var provider = CreateNLogLoggerProvider(serviceProvider, config, opt, logFactory);
                 // Delay initialization of targets until we have loaded config-settings
-                LogManager.Configuration = configuration;
+                logFactory.Configuration = configuration;
                 return provider;
             });
             return builder;

--- a/src/NLog.Web.AspNetCore/NLog.Web.AspNetCore.csproj
+++ b/src/NLog.Web.AspNetCore/NLog.Web.AspNetCore.csproj
@@ -70,7 +70,7 @@ This version adds support for ASP.NET Core 3 and some nice renderers has been ad
     <DefineConstants>$(DefineConstants);ASP_NET_CORE;ASP_NET_CORE3</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NLog.Extensions.Logging" Version="1.6.1" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="1.6.2" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <Reference Include="System" />

--- a/src/NLog.Web.AspNetCore/NLog.Web.AspNetCore.csproj
+++ b/src/NLog.Web.AspNetCore/NLog.Web.AspNetCore.csproj
@@ -20,16 +20,8 @@ Supported platforms:
     <PackageId>NLog.Web.AspNetCore</PackageId>
     <PackageTags>logging;log;NLog;web;aspnet;aspnetcore;MVC;Microsoft.Extensions.Logging;httpcontext;session</PackageTags>
     <PackageReleaseNotes>
-This version adds support for ASP.NET Core 3 and some nice renderers has been added and improved!
-
-- Support ASP.NET Core 3 (@snakefoot, @304NotModified)
-- Added example with ASP.NET Core 3 (@304NotModified)
-- Added ${aspnet-response-statuscode} - rendering response status code (@304NotModified, @ThomasArdal)
-- Added ${aspnet-request-headers} - rendering headers for ASP.NET and ASP.NET Core (@ThomasArdal)
-- ${aspnet-request-cookie} - Added Exclude option (@snakefoot)
-- ${aspnet-request-cookie} (without cookienames) will render all cookies (@304NotModified)
-- Added AddNLog with functor to create/initialize LogFactory for NLogLoggingProvider (@snakefoot)
-- AddNLog-methods for ILoggingBuilder (@snakefoot)
+- ${aspnet-traceidentifier} should automatically check Activity.Current.Id for NetCore3 (@snakefoot)
+- Improved AddNLog with LoggingConfiguration to handle custom LogFactory (@snakefoot)
     </PackageReleaseNotes>
     <PackageIconUrl>https://nlog-project.org/N.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/NLog/NLog.Web</PackageProjectUrl>

--- a/src/NLog.Web.AspNetCore/NLogAspNetCoreOptions.cs
+++ b/src/NLog.Web.AspNetCore/NLogAspNetCoreOptions.cs
@@ -1,5 +1,4 @@
-﻿#if ASP_NET_CORE
-using System;
+﻿using System;
 using System.ComponentModel;
 using NLog.Extensions.Logging;
 
@@ -23,4 +22,3 @@ namespace NLog.Web
         public static NLogAspNetCoreOptions Default { get; } = new NLogAspNetCoreOptions();
     }
 }
-#endif

--- a/src/NLog.Web/NLog.Web.csproj
+++ b/src/NLog.Web/NLog.Web.csproj
@@ -39,7 +39,7 @@ For ASP.NET Core: Check https://www.nuget.org/packages/NLog.Web.AspNetCore
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NLog" Version="4.6.7" />
+    <PackageReference Include="NLog" Version="4.6.8" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Web" />

--- a/src/NLog.Web/NLog.Web.csproj
+++ b/src/NLog.Web/NLog.Web.csproj
@@ -18,10 +18,7 @@ For ASP.NET Core: Check https://www.nuget.org/packages/NLog.Web.AspNetCore
     <PackageId>NLog.Web</PackageId>
     <PackageTags>nlog;log;logging;target;layoutrenderer;web;asp.net;MVC;httpcontext</PackageTags>
     <PackageReleaseNotes>
-- Added ${aspnet-response-statuscode} - rendering response status code (@304NotModified, @ThomasArdal)
-- Added ${aspnet-request-headers} - rendering headers for ASP.NET and ASP.NET Core (@ThomasArdal)
-- ${aspnet-request-cookie} - Added Exclude option (@snakefoot)
-- ${aspnet-request-cookie} (without cookienames) will render all cookies (@304NotModified)
+
     </PackageReleaseNotes>
     <PackageIconUrl>https://nlog-project.org/N.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/NLog/NLog.Web</PackageProjectUrl>

--- a/src/NLog.Web/Properties/AssemblyInfo.cs
+++ b/src/NLog.Web/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // Setting ComVisible to false makes the types in this assembly not visible

--- a/src/Shared/Enums/AspNetRequestLayoutOutputFormat.cs
+++ b/src/Shared/Enums/AspNetRequestLayoutOutputFormat.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace NLog.Web.Enums
 {
     /// <summary>

--- a/src/Shared/Internal/PropertyReader.cs
+++ b/src/Shared/Internal/PropertyReader.cs
@@ -1,10 +1,10 @@
 using System;
-using System.Reflection;
 using System.Linq;
+using System.Reflection;
 
 namespace NLog.Web.Internal
 {
-    internal class PropertyReader
+    internal static class PropertyReader
     {
         /// <summary>
         /// Get value of a property
@@ -27,7 +27,7 @@ namespace NLog.Web.Internal
 
         private static object GetValueAsNestedProperties<T>(string key, T container, Func<T, string, object> getVal)
         {
-            var path = key.IndexOf('.') >= 0 ? key.Split(new[] {'.'}, StringSplitOptions.RemoveEmptyEntries) : null;
+            var path = key.IndexOf('.') >= 0 ? key.Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries) : null;
 
             var value = getVal(container, path?.First() ?? key);
             if (value != null && path?.Length > 1)

--- a/src/Shared/LayoutRenderers/AspNetAppBasePathLayoutRenderer.cs
+++ b/src/Shared/LayoutRenderers/AspNetAppBasePathLayoutRenderer.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.IO;
 using System.Text;
-using NLog.Config;
-using NLog.LayoutRenderers;
 #if ASP_NET_CORE
+using System.IO;
 #if ASP_NET_CORE1 || ASP_NET_CORE2
 using Microsoft.AspNetCore.Hosting;
 using IHostEnvironment = Microsoft.AspNetCore.Hosting.IHostingEnvironment;
@@ -16,6 +14,8 @@ using NLog.Web.DependencyInjection;
 #else
 using System.Web.Hosting;
 #endif
+using NLog.Config;
+using NLog.LayoutRenderers;
 
 namespace NLog.Web.LayoutRenderers
 {

--- a/src/Shared/LayoutRenderers/AspNetTraceIdentifierLayoutRenderer.cs
+++ b/src/Shared/LayoutRenderers/AspNetTraceIdentifierLayoutRenderer.cs
@@ -4,7 +4,6 @@ using NLog.Config;
 using NLog.LayoutRenderers;
 #if ASP_NET_CORE
 using Microsoft.AspNetCore.Http;
-
 #endif
 
 namespace NLog.Web.LayoutRenderers
@@ -23,7 +22,20 @@ namespace NLog.Web.LayoutRenderers
             builder.Append(LookupTraceIdentifier(httpContext));
         }
 
-#if ASP_NET_CORE
+        /// <summary>
+        /// Ignore the System.Diagnostics.Activity.Current.Id value (AspNetCore3 uses ActivityId by default)
+        /// </summary>
+        public bool IgnoreActivityId { get; set; }
+
+#if ASP_NET_CORE3
+        private string LookupTraceIdentifier(HttpContext httpContext)
+        {
+            if (IgnoreActivityId)
+                return httpContext.TraceIdentifier;
+            else
+                return System.Diagnostics.Activity.Current?.Id ?? httpContext.TraceIdentifier;
+        }
+#elif ASP_NET_CORE
         private string LookupTraceIdentifier(HttpContext httpContext)
         {
             return httpContext.TraceIdentifier;

--- a/tests/NLog.Web.AspNetCore.Tests/NLog.Web.AspNetCore.Tests.csproj
+++ b/tests/NLog.Web.AspNetCore.Tests/NLog.Web.AspNetCore.Tests.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
     <PackageReference Include="Microsoft.AspNetCore" Version="1.1.1" />

--- a/tests/NLog.Web.AspNetCore.Tests/NLog.Web.AspNetCore.Tests.csproj
+++ b/tests/NLog.Web.AspNetCore.Tests/NLog.Web.AspNetCore.Tests.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
     <PackageReference Include="Microsoft.AspNetCore" Version="1.1.1" />

--- a/tests/NLog.Web.Tests/NLog.Web.Tests.csproj
+++ b/tests/NLog.Web.Tests/NLog.Web.Tests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="System.ComponentModel.Composition" Version="4.*" />
     <PackageReference Include="System.IO.Compression" Version="4.*" />
     <PackageReference Include="System.Net.Http" Version="4.*" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
     <PackageReference Include="NSubstitute" Version="4.2.1" />

--- a/tests/NLog.Web.Tests/NLog.Web.Tests.csproj
+++ b/tests/NLog.Web.Tests/NLog.Web.Tests.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="System.Net.Http" Version="4.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
     <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/tests/NLog.Web.Tests/NLog.Web.Tests.csproj
+++ b/tests/NLog.Web.Tests/NLog.Web.Tests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="System.IO.Compression" Version="4.*" />
     <PackageReference Include="System.Net.Http" Version="4.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
     <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />

--- a/tests/NLog.Web.Tests/NLog.Web.Tests.csproj
+++ b/tests/NLog.Web.Tests/NLog.Web.Tests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="System.ComponentModel.Composition" Version="4.*" />
     <PackageReference Include="System.IO.Compression" Version="4.*" />
     <PackageReference Include="System.Net.Http" Version="4.*" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
     <PackageReference Include="NSubstitute" Version="4.2.1" />

--- a/tests/Shared/LayoutRenderers/AspNetTraceIdentifierRendererTests.cs
+++ b/tests/Shared/LayoutRenderers/AspNetTraceIdentifierRendererTests.cs
@@ -44,6 +44,26 @@ namespace NLog.Web.Tests.LayoutRenderers
             Assert.Equal(expectedResult.ToString(), result);
         }
 
+#if ASP_NET_CORE3
+        [Fact]
+        public void AvailableActivityIdOverridesGuid()
+        {
+            // Arrange
+            var (renderer, httpContext) = CreateWithHttpContext();
+
+            var expectedResult = System.Guid.NewGuid();
+            SetTraceIdentifier(httpContext, expectedResult);
+
+            System.Diagnostics.Activity.Current = new System.Diagnostics.Activity("MyOperation").Start();
+            
+            // Act
+            string result = renderer.Render(new LogEventInfo());
+
+            // Assert
+            Assert.Equal(System.Diagnostics.Activity.Current.Id, result);
+        }
+#endif
+
         private static void SetTraceIdentifier(HttpContextBase httpContext, Guid? expectedResult)
         {
 #if ASP_NET_CORE


### PR DESCRIPTION
Think we should release ver. 4.9.1 with NLog.Extension.Logging 1.6.2 and NLog 4.6.8, before upgrading to NLog 4.7

Have not yet bumped version number in this PR (Incase you have other items to merge before release)