### PR TITLE
LogManager.Setup() - LoadConfigurationFromAppSettings

### DIFF
--- a/examples/ASP.NET Core 2/Visual Studio 2017/ASP.NET Core 2 - VS2017/Program.cs
+++ b/examples/ASP.NET Core 2/Visual Studio 2017/ASP.NET Core 2 - VS2017/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using NLog.Extensions.Logging;
 using NLog.Web;
 
 namespace NLog.Web.AspNetCore2.Example
@@ -11,7 +12,13 @@ namespace NLog.Web.AspNetCore2.Example
     {
         public static void Main(string[] args)
         {
-            var logger = NLog.Web.NLogBuilder.ConfigureNLog("nlog.config").GetCurrentClassLogger();
+            var config = new ConfigurationBuilder().Build();
+
+            var logger = LogManager.Setup()
+                                   .RegisterNLogWeb(config)
+                                   .LoadConfigurationFromFile("nlog.config")
+                                   .GetCurrentClassLogger();
+
             try
             {
                 logger.Debug("init main");

--- a/examples/ASP.NET Core 3/ASP.NET Core 3 - VS2019/Program.cs
+++ b/examples/ASP.NET Core 3/ASP.NET Core 3 - VS2019/Program.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using NLog;
 using NLog.Web;
 
 namespace ASP.NET_Core_3___VS2019
@@ -14,7 +15,10 @@ namespace ASP.NET_Core_3___VS2019
     {
         public static void Main(string[] args)
         {
-            var logger = NLog.Web.NLogBuilder.ConfigureNLog("nlog.config").GetCurrentClassLogger();
+            var logger = LogManager.Setup()
+                                   .LoadConfigurationFromAppSettings()
+                                   .GetCurrentClassLogger();
+
             try
             {
                 logger.Debug("init main");

--- a/src/NLog.Web.AspNetCore/Config/SetupBuilderExtensions.cs
+++ b/src/NLog.Web.AspNetCore/Config/SetupBuilderExtensions.cs
@@ -1,0 +1,103 @@
+﻿using System;
+#if !ASP_NET_CORE1 && !ASP_NET_CORE2
+using System.IO;
+using System.Linq;
+#endif
+using Microsoft.Extensions.Configuration;
+using NLog.Config;
+using NLog.Extensions.Logging;
+
+namespace NLog.Web
+{
+    /// <summary>
+    /// Extension methods to setup LogFactory options
+    /// </summary>
+    public static class SetupBuilderExtensions
+    {
+#if !ASP_NET_CORE1 && !ASP_NET_CORE2
+        /// <summary>
+        /// Loads NLog LoggingConfiguration from appsettings.json from the NLog-section
+        /// </summary>
+        public static ISetupBuilder LoadConfigurationFromAppSettings(this ISetupBuilder setupBuilder, string basePath = null, string environment = null, string nlogConfigSection = "NLog", bool optional = true, bool reloadOnChange = false)
+        {
+            environment = environment ?? GetAspNetCoreEnvironment("DOTNET_ENVIRONMENT") ?? GetAspNetCoreEnvironment("ASPNETCORE_ENVIRONMENT") ?? "Production";
+
+            var builder = new ConfigurationBuilder()
+                // Host Configuration
+                .SetBasePath(basePath ?? Directory.GetCurrentDirectory())
+                .AddEnvironmentVariables(prefix: "ASPNETCORE_")
+                .AddEnvironmentVariables(prefix: "DOTNET_")
+                // App Configuration
+                .AddJsonFile("appsettings.json", optional, reloadOnChange)
+                .AddJsonFile($"appsettings.{environment}.json", optional: true, reloadOnChange: reloadOnChange)
+                .AddEnvironmentVariables();
+
+            var config = builder.Build();
+            if (!string.IsNullOrEmpty(nlogConfigSection) && config.GetSection(nlogConfigSection)?.GetChildren().Any() == true)
+            {
+                return setupBuilder.SetupExtensions(e => e.RegisterNLogWeb()).LoadConfigurationFromSection(config, nlogConfigSection);
+            }
+            else
+            {
+                setupBuilder.SetupExtensions(e => e.RegisterNLogWeb().RegisterConfigSettings(config));
+
+                if (!string.IsNullOrEmpty(basePath))
+                {
+                    if (!string.IsNullOrEmpty(environment))
+                    {
+                        setupBuilder.LoadConfigurationFromFile(Path.Combine(basePath, $"nlog.{environment}.config"), optional: true);
+                    }
+
+                    setupBuilder.LoadConfigurationFromFile(Path.Combine(basePath, "nlog.config"), optional: true);
+                }
+                else if (!string.IsNullOrEmpty(environment))
+                {
+                    setupBuilder.LoadConfigurationFromFile($"nlog.{environment}.config", optional: true);
+                }
+
+                return setupBuilder.LoadConfigurationFromFile();    // No effect, if config already loaded
+            }
+        }
+
+        private static string GetAspNetCoreEnvironment(string variableName)
+        {
+            try
+            {
+                var environment = Environment.GetEnvironmentVariable(variableName);
+                if (string.IsNullOrWhiteSpace(environment))
+                    return null;
+
+                return environment.Trim();
+            }
+            catch (Exception ex)
+            {
+                NLog.Common.InternalLogger.Error(ex, "Failed to lookup environment variable {0}", variableName);
+                return null;
+            }
+        }
+#endif
+
+        /// <summary>
+        /// Convience method to register aspnet-layoutrenders in NLog.Web as one-liner before loading NLog.config
+        /// </summary>
+        /// <remarks>
+        /// If not providing <paramref name="serviceProvider"/>, then output from aspnet-layoutrenderers will remain empty
+        /// </remarks>
+        public static ISetupBuilder RegisterNLogWeb(this ISetupBuilder setupBuilder, IConfiguration configuration = null, IServiceProvider serviceProvider = null)
+        {
+            setupBuilder.SetupExtensions(e => e.RegisterNLogWeb(serviceProvider));
+
+            if (configuration == null && serviceProvider != null)
+            {
+                configuration = serviceProvider.GetService(typeof(IConfiguration)) as IConfiguration;
+            }
+
+            if (configuration != null)
+            { 
+                setupBuilder.SetupExtensions(e => e.RegisterConfigSettings(configuration));
+            }
+
+            return setupBuilder;
+        }
+    }
+}

--- a/src/NLog.Web.AspNetCore/Config/SetupExtensionsBuilderExtensions.cs
+++ b/src/NLog.Web.AspNetCore/Config/SetupExtensionsBuilderExtensions.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Reflection;
+using Microsoft.Extensions.Configuration;
+using NLog.Config;
+using NLog.Extensions.Logging;
+using NLog.Web.DependencyInjection;
+
+namespace NLog.Web
+{
+    /// <summary>
+    /// Extension methods to setup NLog extensions, so they are known when loading NLog LoggingConfiguration
+    /// </summary>
+    public static class SetupExtensionsBuilderExtensions
+    {
+        /// <summary>
+        /// Replace with version from NLog.Extension.Logging when it has been released with NLog 4.7
+        /// </summary>
+        internal static ISetupExtensionsBuilder RegisterConfigSettings(this ISetupExtensionsBuilder setupBuilder, IConfiguration configuration)
+        {
+            ConfigSettingLayoutRenderer.DefaultConfiguration = configuration;
+            return setupBuilder.RegisterLayoutRenderer<ConfigSettingLayoutRenderer>("configsetting");
+        }
+
+        /// <summary>
+        /// Register the NLog.Web.AspNetCore LayoutRenderers
+        /// </summary>
+        /// <remarks>
+        /// If not providing <paramref name="serviceProvider"/>, then output from aspnet-layoutrenderers will remain empty
+        /// </remarks>
+        public static ISetupExtensionsBuilder RegisterNLogWeb(this ISetupExtensionsBuilder setupBuilder, IServiceProvider serviceProvider = null)
+        {
+            if (serviceProvider != null)
+            {
+                ServiceLocator.ServiceProvider = serviceProvider;
+            }
+
+            return setupBuilder.RegisterAssembly(typeof(NLogAspNetCoreOptions).GetTypeInfo().Assembly);
+        }
+    }
+}


### PR DESCRIPTION
Now you can do this in NetCore3:

```c#
var logger = NLog.LogManager.Setup().LoadConfigurationFromAppSettings().GetCurrentClassLogger();
```

And it replaces this for NetCore3 (Could consider making it obsolete):

```c#
var logger = NLog.Web.NLogBuilder.ConfigureNLog("nlog.config").GetCurrentClassLogger();
```

And also configures ${configsetting} and also checks appsetting.json if it contains a NLog-section with NLog config. But if none found, then NLog automatic load of NLog.config takes over.


For NetCore2 then one can do this instead of `NLogBuilder.ConfigureNLog`:
```c#
var builder = new ConfigurationBuilder()
                .SetBasePath(basePath ?? Directory.GetCurrentDirectory())
                .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
                .AddJsonFile($"appsettings.{environment}.json", optional: true)
                .AddEnvironmentVariables();
var config = builder.Build();
var logger = LogManager.Setup()
                       .RegisterNLogWeb(config)
                       .LoadConfigurationFromFile("nlog.config")
                       .GetCurrentClassLogger();
```

This PR is a proof-of-concept, and should be delayed until NLog.Extension.Logging has been released with NLog 4.7 (Or maybe NLog 4.7.1)