### PR TITLE
Handle int for session value

### DIFF
--- a/src/NLog.Web.AspNetCore/LayoutRenderers/SessionValueType.cs
+++ b/src/NLog.Web.AspNetCore/LayoutRenderers/SessionValueType.cs
@@ -1,0 +1,20 @@
+#if ASP_NET_CORE
+
+namespace NLog.Web.LayoutRenderers
+{
+    /// <summary>
+    /// The type of a value
+    /// </summary>
+    public enum SessionValueType
+    {
+        /// <summary>
+        /// String
+        /// </summary>
+        String,
+        /// <summary>
+        /// Int32
+        /// </summary>
+        Int32
+    }
+}
+#endif

--- a/src/Shared/Internal/HttpContextExtensions.cs
+++ b/src/Shared/Internal/HttpContextExtensions.cs
@@ -82,6 +82,20 @@ namespace NLog.Web.Internal
 
             return Encoding.UTF8.GetString(data);
         }
+
+        public static int? GetInt32(this ISession session, string key)
+        {
+            if (!session.TryGetValue(key, out var data))
+            {
+                return null;
+            }
+
+            if (data == null || data.Length < 4)
+            {
+                return null;
+            }
+            return data[0] << 24 | data[1] << 16 | data[2] << 8 | data[3];
+        }
 #endif
 
 #if !ASP_NET_CORE

--- a/src/Shared/Internal/HttpContextExtensions.cs
+++ b/src/Shared/Internal/HttpContextExtensions.cs
@@ -62,7 +62,7 @@ namespace NLog.Web.Internal
         }
 #endif
 
-#if ASP_NET_CORE
+#if ASP_NET_CORE1 || ASP_NET_CORE2
         internal static string GetString(this ISession session, string key)
         {
             if (!session.TryGetValue(key, out var data))

--- a/src/Shared/LayoutRenderers/AspNetSessionValueLayoutRenderer.cs
+++ b/src/Shared/LayoutRenderers/AspNetSessionValueLayoutRenderer.cs
@@ -131,8 +131,8 @@ namespace NLog.Web.LayoutRenderers
             switch (ValueType)
             {
                 case SessionValueType.Int32:
-                    return HttpContextExtensions.GetInt32(session, key);
-                default: return HttpContextExtensions.GetString(session, key);
+                    return session.GetInt32(key);
+                default: return session.GetString(key);
             }
         }
 #endif

--- a/src/Shared/LayoutRenderers/AspNetSessionValueLayoutRenderer.cs
+++ b/src/Shared/LayoutRenderers/AspNetSessionValueLayoutRenderer.cs
@@ -76,7 +76,7 @@ namespace NLog.Web.LayoutRenderers
         /// <summary>
         /// The hype of the value.
         /// </summary>
-        public SessionValueType ValueType = SessionValueType.String;
+        public SessionValueType ValueType { get; set; } = SessionValueType.String;
 #endif
 
         /// <summary>

--- a/src/Shared/LayoutRenderers/AspNetSessionValueLayoutRenderer.cs
+++ b/src/Shared/LayoutRenderers/AspNetSessionValueLayoutRenderer.cs
@@ -6,6 +6,8 @@ using NLog.LayoutRenderers;
 using NLog.Web.Internal;
 #if !ASP_NET_CORE
 using System.Web;
+#else
+using Microsoft.AspNetCore.Http;
 #endif
 
 namespace NLog.Web.LayoutRenderers
@@ -70,6 +72,13 @@ namespace NLog.Web.LayoutRenderers
         /// <docgen category='Rendering Options' order='10' />
         public CultureInfo Culture { get; set; }
 
+#if ASP_NET_CORE
+        /// <summary>
+        /// The hype of the value.
+        /// </summary>
+        public SessionValueType ValueType = SessionValueType.String;
+#endif
+
         /// <summary>
         /// Renders the specified ASP.NET Session value and appends it to the specified <see cref="StringBuilder" />.
         /// </summary>
@@ -102,7 +111,7 @@ namespace NLog.Web.LayoutRenderers
             object value;
             try
             {
-                value = PropertyReader.GetValue(Variable, contextSession, (session, key) => session.GetString(key), EvaluateAsNestedProperties);
+                value = PropertyReader.GetValue(Variable, contextSession, (session, key) => GetSessionValue(session, key), EvaluateAsNestedProperties);
             }
             finally
             {
@@ -115,5 +124,17 @@ namespace NLog.Web.LayoutRenderers
                 builder.Append(Convert.ToString(value, formatProvider));
             }
         }
+
+#if ASP_NET_CORE
+        private object GetSessionValue(ISession session, string key)
+        {
+            switch (ValueType)
+            {
+                case SessionValueType.Int32:
+                    return HttpContextExtensions.GetInt32(session, key);
+                default: return HttpContextExtensions.GetString(session, key);
+            }
+        }
+#endif
     }
 }

--- a/tests/Shared/LayoutRenderers/AspNetSessionValueLayoutRendererTests2.cs
+++ b/tests/Shared/LayoutRenderers/AspNetSessionValueLayoutRendererTests2.cs
@@ -23,7 +23,7 @@ namespace NLog.Web.Tests.LayoutRenderers
     public class AspNetSessionValueLayoutRendererTests2 : LayoutRenderersTestBase<AspNetSessionValueLayoutRenderer>
     {
         [Fact]
-        public void SingleItemRendersCorrectValue()
+        public void SingleStringItemRendersCorrectValue()
         {
             // Arrange
             var (renderer, _) = CreateRenderer();
@@ -34,6 +34,20 @@ namespace NLog.Web.Tests.LayoutRenderers
 
             // Assert
             Assert.Equal("https://duckduckgo.com", result);
+        }
+
+        [Fact]
+        public void SingleIntItemRendersCorrectValue()
+        {
+            // Arrange
+            var (renderer, _) = CreateRenderer();
+            renderer.Variable = "b";
+
+            // Act
+            string result = renderer.Render(LogEventInfo.CreateNullEvent());
+
+            // Assert
+            Assert.Equal("123", result);
         }
 
         [Fact]
@@ -50,12 +64,15 @@ namespace NLog.Web.Tests.LayoutRenderers
             Assert.Empty(result);
         }
 
+
+
         private static (AspNetSessionValueLayoutRenderer, HttpContext) CreateRenderer(bool throwsError = false)
         {
             var (renderer, httpContext) = CreateWithHttpContext();
 
             var mockSession = new SessionMock(throwsError);
             mockSession.SetString("a", "https://duckduckgo.com");
+            mockSession.SetInt32("b", 123);
             httpContext.Session = mockSession;
             httpContext.Items = new Dictionary<object, object>();
             var sessionFeature = new SessionFeatureMock(mockSession);

--- a/tests/Shared/LayoutRenderers/AspNetSessionValueLayoutRendererTests2.cs
+++ b/tests/Shared/LayoutRenderers/AspNetSessionValueLayoutRendererTests2.cs
@@ -42,6 +42,7 @@ namespace NLog.Web.Tests.LayoutRenderers
             // Arrange
             var (renderer, _) = CreateRenderer();
             renderer.Variable = "b";
+            renderer.ValueType = SessionValueType.Int32;
 
             // Act
             string result = renderer.Render(LogEventInfo.CreateNullEvent());


### PR DESCRIPTION
see https://stackoverflow.com/questions/62054400/can-the-nlog-aspnet-sessionvariable-intid-renderer-extract-display-integers-f/62054553#62054553

I think the only solution here is to add a type option to the renderer. What do you think @snakefoot ?

(If it's 4 bytes long, we only know it **could** be an int)

PS: these are the extensions in ASP.NET Core:

```c#
namespace Microsoft.AspNetCore.Http
{
    public static class SessionExtensions
    {
        public static void SetInt32(this ISession session, string key, int value)
        {
            var bytes = new byte[]
            {
                (byte)(value >> 24),
                (byte)(0xFF & (value >> 16)),
                (byte)(0xFF & (value >> 8)),
                (byte)(0xFF & value)
            };
            session.Set(key, bytes);
        }

        public static int? GetInt32(this ISession session, string key)
        {
            var data = session.Get(key);
            if (data == null || data.Length < 4)
            {
                return null;
            }
            return data[0] << 24 | data[1] << 16 | data[2] << 8 | data[3];
        }

        public static void SetString(this ISession session, string key, string value)
        {
            session.Set(key, Encoding.UTF8.GetBytes(value));
        }

        public static string GetString(this ISession session, string key)
        {
            var data = session.Get(key);
            if (data == null)
            {
                return null;
            }
            return Encoding.UTF8.GetString(data);
        }

        public static byte[] Get(this ISession session, string key)
        {
            byte[] value = null;
            session.TryGetValue(key, out value);
            return value;
        }
    }
}
```
