### PR TITLE
Added option to trim aspnet-request-posted-body.

### DIFF
--- a/src/Shared/LayoutRenderers/AspNetRequestPostedBody.cs
+++ b/src/Shared/LayoutRenderers/AspNetRequestPostedBody.cs
@@ -6,6 +6,7 @@ using NLog.Common;
 using NLog.Config;
 using NLog.LayoutRenderers;
 using NLog.Web.Internal;
+using System.Text.RegularExpressions;
 
 #if !ASP_NET_CORE
 using System.Web;
@@ -41,6 +42,12 @@ namespace NLog.Web.LayoutRenderers
         public int MaxContentLength { get; set; } = Size30Kilobytes;
 
         /// <summary>
+        /// Boolean for if content should be trimmed for excess spaces.
+        /// Default is false.
+        /// </summary>
+        public bool TrimContent { get; set; } = false;
+
+        /// <summary>
         /// Renders the ASP.NET posted body
         /// </summary>
         /// <param name="builder">The <see cref="StringBuilder" /> to append the rendered data to.</param>
@@ -60,6 +67,10 @@ namespace NLog.Web.LayoutRenderers
             }
 
             var content = BodyToString(body);
+
+            if (TrimContent)
+                content = new Regex(@"\s{2,}").Replace(content.Trim(), " ");
+
             builder.Append(content);
         }
 

--- a/tests/Shared/LayoutRenderers/AspNetRequestPostedBodyTests.cs
+++ b/tests/Shared/LayoutRenderers/AspNetRequestPostedBodyTests.cs
@@ -90,6 +90,35 @@ namespace NLog.Web.Tests.LayoutRenderers
             Assert.Equal(expectedResult, result);
         }
 
+        [Theory]
+        [InlineData("   ABC   DEF GH I J   KL ", true, "ABC DEF GH I J KL")]
+        [InlineData("   ABC   DEF GH I J   KL ", false, "   ABC   DEF GH I J   KL ")]
+        public void TrimContentTrimsCorrectlyTest(string body, bool trimContent, string expectedResult)
+        {
+            TrimContentTrimsCorrectly(body, trimContent, expectedResult, false);
+#if ASP_NET_CORE
+            TrimContentTrimsCorrectly(body, trimContent, expectedResult, true);
+#endif
+        }
+
+        private static void TrimContentTrimsCorrectly(string body, bool trimContent, string expectedResult, bool canReadOnce)
+        {
+            // Arrange
+            var (renderer, httpContext) = CreateWithHttpContext();
+            renderer.TrimContent = trimContent;
+
+            var stream = CreateStream(body, canReadOnce);
+            SetBodyStream(httpContext, stream);
+
+            var logEventInfo = new LogEventInfo();
+
+            // Act
+            string result = renderer.Render(logEventInfo);
+
+            // Assert
+            Assert.Equal(expectedResult, result);
+        }
+
         private static void SetBodyStream(HttpContextBase httpContext, Stream stream)
         {
 #if ASP_NET_CORE


### PR DESCRIPTION
With this change this:
`{_______"test":_"Some_____value____"_______}`
becomes this:
`{_"test":_"Some_value_"_}`
in the log.

Possible future change is to only trim outside json values.