### PR TITLE
Added support for HttpContext.User claim lookup using ${aspnet-user-claim}

### DIFF
--- a/src/NLog.Web.AspNetCore/LayoutRenderers/AspNetUserClaimLayoutRenderer.cs
+++ b/src/NLog.Web.AspNetCore/LayoutRenderers/AspNetUserClaimLayoutRenderer.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Reflection;
+using System.Security.Claims;
+using System.Text;
+using NLog.Common;
+using NLog.Config;
+using NLog.LayoutRenderers;
+
+namespace NLog.Web.LayoutRenderers
+{
+    /// <summary>
+    /// ASP.NET User ClaimType Value Lookup.
+    /// </summary>
+    [LayoutRenderer("aspnet-user-claim")]
+    [ThreadSafe]
+    public class AspNetUserClaimLayoutRenderer : AspNetLayoutRendererBase
+    {
+        /// <summary>
+        /// Key to lookup using <see cref="ClaimsIdentity.FindFirst(string)"/> with fallback to <see cref="ClaimsPrincipal.FindFirst(string)"/>
+        /// </summary>
+        /// <remarks>
+        /// When value is prefixed with "ClaimTypes." (Remember dot) then ít will lookup in well-known claim types from <see cref="ClaimTypes"/>. Ex. ClaimsTypes.Name
+        /// </remarks>
+        [RequiredParameter]
+        [DefaultParameter]
+        public string ClaimType { get; set; }
+
+        /// <inheritdoc />
+        protected override void InitializeLayoutRenderer()
+        {
+            if (ClaimType?.Trim().StartsWith("ClaimTypes.", StringComparison.OrdinalIgnoreCase) == true || ClaimType?.Trim().StartsWith("ClaimType.", StringComparison.OrdinalIgnoreCase) == true)
+            {
+                var fieldName = ClaimType.Substring(ClaimType.IndexOf(".") + 1).Trim();
+                var claimTypesField = typeof(ClaimTypes).GetField(fieldName, BindingFlags.Static | BindingFlags.Public);
+                if (claimTypesField != null)
+                {
+                    ClaimType = claimTypesField.GetValue(null) as string ?? ClaimType.Trim();
+                }
+            }
+
+            base.InitializeLayoutRenderer();
+        }
+
+        /// <summary>
+        /// Renders the specified ASP.NET User.Identity.AuthenticationType variable and appends it to the specified <see cref="StringBuilder" />.
+        /// </summary>
+        /// <param name="builder">The <see cref="StringBuilder" /> to append the rendered data to.</param>
+        /// <param name="logEvent">Logging event.</param>
+        protected override void DoAppend(StringBuilder builder, LogEventInfo logEvent)
+        {
+            try
+            {
+                var claimsPrincipel = HttpContextAccessor.HttpContext.User;
+                if (claimsPrincipel == null)
+                {
+                    InternalLogger.Debug("aspnet-user-claim - HttpContext User is null");
+                    return;
+                }
+
+                var claimsIdentity = claimsPrincipel?.Identity as ClaimsIdentity;    // Prioritize primary identity
+                var claim = claimsIdentity?.FindFirst(ClaimType) ?? claimsPrincipel.FindFirst(ClaimType);
+                if (claim != null)
+                {
+                    builder.Append(claim.Value);
+                }
+            }
+            catch (ObjectDisposedException)
+            {
+                //ignore ObjectDisposedException, see https://github.com/NLog/NLog.Web/issues/83
+            }
+        }
+    }
+}

--- a/tests/NLog.Web.AspNetCore.Tests/AspNetUserClaimLayoutRendererTests.cs
+++ b/tests/NLog.Web.AspNetCore.Tests/AspNetUserClaimLayoutRendererTests.cs
@@ -1,0 +1,47 @@
+﻿using System.Security.Principal;
+using Microsoft.Extensions.Primitives;
+using HttpContextBase = Microsoft.AspNetCore.Http.HttpContext;
+using NLog.Web.LayoutRenderers;
+using NSubstitute;
+using Xunit;
+
+namespace NLog.Web.Tests.LayoutRenderers
+{
+    public class AspNetUserClaimLayoutRendererTests : LayoutRenderersTestBase<AspNetUserClaimLayoutRenderer>
+    {
+        [Fact]
+        public void NullUserIdentityRendersEmptyString()
+        {
+            // Arrange
+            var (renderer, httpContext) = CreateWithHttpContext();
+            renderer.ClaimType = "Name";
+            httpContext.User.Identity.Returns(null as IIdentity);
+
+            // Act
+            string result = renderer.Render(new LogEventInfo());
+
+            // Assert
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void UserClaimTypeNameRendersValue()
+        {
+            // Arrange
+            var (renderer, httpContext) = CreateWithHttpContext();
+            renderer.ClaimType = "ClaimType.Name";
+
+            var expectedResult = "value";
+            var expectedName = System.Security.Claims.ClaimTypes.Name;
+            var identity = Substitute.For<System.Security.Claims.ClaimsIdentity>();
+            identity.FindFirst(expectedName).Returns(new System.Security.Claims.Claim(expectedName, expectedResult));
+            httpContext.User.Identity.Returns(identity);
+
+            // Act
+            string result = renderer.Render(new LogEventInfo());
+
+            // Assert
+            Assert.Equal(expectedResult, result);
+        }
+    }
+}

--- a/tests/NLog.Web.AspNetCore.Tests/NLog.Web.AspNetCore.Tests.csproj
+++ b/tests/NLog.Web.AspNetCore.Tests/NLog.Web.AspNetCore.Tests.csproj
@@ -39,7 +39,6 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Properties\" />
-    <Compile Include="..\Shared\**\*.cs" />
+	<Compile Include="..\Shared\**\*.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Example: `${aspnet-user-claim:ClaimTypes.Name}` . See also [ClaimTypes](https://docs.microsoft.com/en-us/dotnet/api/system.security.claims.claimtypes)-constants.

Not implemented for NLog.Web (MVC), since it requires NetFramework45.