### PR TITLE
Add AddNLogWeb with NLog LogFactory and NLogAspNetCoreOptions for better isolation

### DIFF
--- a/src/NLog.Web.AspNetCore/AspNetExtensions.cs
+++ b/src/NLog.Web.AspNetCore/AspNetExtensions.cs
@@ -241,6 +241,23 @@ namespace NLog.Web
         }
 
         /// <summary>
+        /// Configure NLog from API
+        /// </summary>
+        /// <param name="builder">The logging builder</param>
+        /// <param name="logFactory">NLog LogFactory</param>
+        /// <param name="options">Options for logging to NLog with Dependency Injected loggers</param>
+        public static ILoggingBuilder AddNLogWeb(this ILoggingBuilder builder, LogFactory logFactory, NLogAspNetCoreOptions options)
+        {
+            AddNLogLoggerProvider(builder.Services, null, options, (serviceProvider, config, opt) =>
+            {
+                logFactory = logFactory ?? LogManager.LogFactory;
+                var provider = CreateNLogLoggerProvider(serviceProvider, config, opt, logFactory);
+                return provider;
+            });
+            return builder;
+        }
+
+        /// <summary>
         /// Use NLog for Dependency Injected loggers.
         /// </summary>
         public static IWebHostBuilder UseNLog(this IWebHostBuilder builder)


### PR DESCRIPTION
Allows one to do this:

            var logFactory = new NLog.LogFactory.Setup()
               .SetupExtensions(e => e.AutoLoadAssemblies(false))
               .RegisterNLogWeb()
               .LoadConfigurationFromFile("nlog.config", optional: false)
               .LoadConfiguration(builder => builder.LogFactory.AutoShutdown = false).LogFactory;

                builder.UseStartup<Startup>()
                        .ConfigureLogging((ctx, logging) =>
                        {
                            logging.ClearProviders();
                            logging.SetMinimumLevel(Microsoft.Extensions.Logging.LogLevel.Debug);
                            logging.AddNLogWeb(logFactory, new NLogAspNetCoreOptions() { ShutdownOnDispose = true });
                        });

So the MEL receives an isolated LogFactory, that is fully initialised (Instead of using the global NLog.LogManager).