### PR TITLE
HttpContext - Extended ObjectDisposedException handling

### DIFF
--- a/src/NLog.Web.AspNetCore/LayoutRenderers/AspNetUserClaimLayoutRenderer.cs
+++ b/src/NLog.Web.AspNetCore/LayoutRenderers/AspNetUserClaimLayoutRenderer.cs
@@ -64,9 +64,9 @@ namespace NLog.Web.LayoutRenderers
                     builder.Append(claim.Value);
                 }
             }
-            catch (ObjectDisposedException)
+            catch (ObjectDisposedException ex)
             {
-                //ignore ObjectDisposedException, see https://github.com/NLog/NLog.Web/issues/83
+                InternalLogger.Debug(ex, "aspnet-user-claim - HttpContext has been disposed");
             }
         }
     }

--- a/src/Shared/Internal/HttpContextExtensions.cs
+++ b/src/Shared/Internal/HttpContextExtensions.cs
@@ -124,6 +124,11 @@ namespace NLog.Web.Internal
                     return null;
                 }
             }
+            catch (ObjectDisposedException ex)
+            {
+                InternalLogger.Debug(ex, "HttpContext Session Disposed.");
+                return null; // System.ObjectDisposedException: IFeatureCollection has been disposed.
+            }
             catch (InvalidOperationException ex)
             {
                 InternalLogger.Debug(ex, "HttpContext Session Lookup failed.");

--- a/src/Shared/LayoutRenderers/AspNetLayoutRendererBase.cs
+++ b/src/Shared/LayoutRenderers/AspNetLayoutRendererBase.cs
@@ -14,8 +14,6 @@ using NLog.Web.DependencyInjection;
 using System.Web;
 #endif
 
-
-
 namespace NLog.Web.LayoutRenderers
 {
     /// <summary>
@@ -72,9 +70,6 @@ namespace NLog.Web.LayoutRenderers
                 return null;
             }
         }
-
-
-
 #endif
 
         /// <summary>

--- a/src/Shared/LayoutRenderers/AspNetRequestUrlRenderer.cs
+++ b/src/Shared/LayoutRenderers/AspNetRequestUrlRenderer.cs
@@ -3,10 +3,10 @@ using System.Text;
 using NLog.Config;
 using NLog.LayoutRenderers;
 using NLog.Web.Internal;
+using NLog.Common;
 #if ASP_NET_CORE
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
-
 #else
 using System.Collections.Specialized;
 using System.Web;
@@ -75,7 +75,14 @@ namespace NLog.Web.LayoutRenderers
                 return;
             }
 
-            RenderUrl(httpRequest, builder);
+            try
+            {
+                RenderUrl(httpRequest, builder);
+            }
+            catch (ObjectDisposedException ex)
+            {
+                InternalLogger.Debug(ex, "aspnet-request-url - HttpContext has been disposed");
+            }
         }
 
 #if !ASP_NET_CORE

--- a/src/Shared/LayoutRenderers/AspNetUserAuthTypeLayoutRenderer.cs
+++ b/src/Shared/LayoutRenderers/AspNetUserAuthTypeLayoutRenderer.cs
@@ -35,9 +35,9 @@ namespace NLog.Web.LayoutRenderers
 
                 builder.Append(identity.AuthenticationType);
             }
-            catch (ObjectDisposedException)
+            catch (ObjectDisposedException ex)
             {
-                //ignore ObjectDisposedException, see https://github.com/NLog/NLog.Web/issues/83
+                InternalLogger.Debug(ex, "aspnet-user-authtype - HttpContext has been disposed");
             }
         }
     }

--- a/src/Shared/LayoutRenderers/AspNetUserIdentityLayoutRenderer.cs
+++ b/src/Shared/LayoutRenderers/AspNetUserIdentityLayoutRenderer.cs
@@ -35,9 +35,9 @@ namespace NLog.Web.LayoutRenderers
 
                 builder.Append(identity.Name);
             }
-            catch (ObjectDisposedException)
+            catch (ObjectDisposedException ex)
             {
-                //ignore ObjectDisposedException, see https://github.com/NLog/NLog.Web/issues/83
+                InternalLogger.Debug(ex, "aspnet-user-identity - HttpContext has been disposed");
             }
         }
     }

--- a/src/Shared/LayoutRenderers/AspNetUserIsAuthenticatedLayoutRenderer.cs
+++ b/src/Shared/LayoutRenderers/AspNetUserIsAuthenticatedLayoutRenderer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text;
+using NLog.Common;
 using NLog.Config;
 using NLog.LayoutRenderers;
 using NLog.Web.LayoutRenderers;
@@ -34,9 +35,9 @@ namespace NLog.Web.AspNetCore.LayoutRenderers
                     builder.Append(0);
                 }
             }
-            catch (ObjectDisposedException)
+            catch (ObjectDisposedException ex)
             {
-                //ignore ObjectDisposedException, see https://github.com/NLog/NLog.Web/issues/83
+                InternalLogger.Debug(ex, "aspnet-user-isAuthenticated - HttpContext has been disposed");
             }
         }
     }


### PR DESCRIPTION
Suppresses `ObjectDisposedException` when HttpContext is no longer active (Avoid crashing when NLog users are wrongly using `ThrowExceptions=true`). Usually caused by NLog-users scheduling work on background-thread that is not awaited so it is runnng after HttpRequest has completed.

Alternative workaround to awaiting the background-task is to suppress the capture of thread-execution-context, so the HttpContext doesn't travel to the background-thread:

```c#
using (ExecutionContext.SuppressFlow())
{
    Task.Run(() => {});
}
```

The correct way of handling this is to ensure logging from non-awaited background-tasks doesn't reach Layout-logic that includes `${aspnet-request}`-Layout-logic (Redirect to NLog targets with simple Layout-logic).