### PR TITLE
NLogRequestLogging - Added DurationThresholdMs + ExcludeRequestPaths

### DIFF
--- a/src/NLog.Web.AspNetCore/NLogRequestLoggingOptions.cs
+++ b/src/NLog.Web.AspNetCore/NLogRequestLoggingOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace NLog.Web
+﻿using System.Collections.Generic;
+
+namespace NLog.Web
 {
     /// <summary>
     /// Options configuration for <see cref="NLogRequestLoggingMiddleware"/>
@@ -11,5 +13,18 @@
         /// Logger-name used for logging http-requests
         /// </summary>
         public string LoggerName { get; set; } = "NLogRequestLogging";
+
+        /// <summary>
+        /// Get or set duration time in milliseconds, before a HttpRequest is seen as slow (Logged as warning)
+        /// </summary>
+        public int DurationThresholdMs { get; set; } = 300;
+
+        /// <summary>
+        /// Gets or sets request-paths where LogLevel should be reduced (Logged as debug)
+        /// </summary>
+        /// <remarks>
+        /// Example '/healthcheck'
+        /// </remarks>
+        public ISet<string> ExcludeRequestPaths { get; } = new HashSet<string>(System.StringComparer.OrdinalIgnoreCase);
     }
 }

--- a/src/NLog.Web/NLogRequestLoggingModule.cs
+++ b/src/NLog.Web/NLogRequestLoggingModule.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Web;
 
 namespace NLog.Web
@@ -9,6 +10,16 @@ namespace NLog.Web
     public class NLogRequestLoggingModule : IHttpModule
     {
         private static readonly NLog.Logger Logger = NLog.LogManager.GetLogger("NLogRequestLogging");
+
+        /// <summary>
+        /// Get or set duration time in milliseconds, before a HttpRequest is seen as slow (Logged as warning)
+        /// </summary>
+        public int DurationThresholdMs { get; set; } = 300;
+
+        /// <summary>
+        /// Gets or sets request-paths where LogLevel should be reduced (Logged as debug)
+        /// </summary>
+        public HashSet<string> ExcludeRequestPaths { get; } = new HashSet<string>(System.StringComparer.OrdinalIgnoreCase);
 
         void IHttpModule.Init(HttpApplication context)
         {
@@ -35,6 +46,10 @@ namespace NLog.Web
                     Logger.Error(exception, "HttpRequest Exception");
                 else if (statusCode < 100 || (statusCode >= 400 && statusCode < 600))
                     Logger.Warn("HttpRequest Failed");
+                else if (IsExcludedHttpRequest(HttpContext.Current))
+                    Logger.Debug("HttpRequest Completed");
+                else if (IsSlowHttpRequest(HttpContext.Current))
+                    Logger.Warn("HttpRequest Slow");
                 else
                     Logger.Info("HttpRequest Completed");
             }
@@ -43,6 +58,40 @@ namespace NLog.Web
         void IHttpModule.Dispose()
         {
             // Nothing here to do
+        }
+
+        private bool IsSlowHttpRequest(HttpContext httpContext)
+        {
+            if (httpContext != null)
+            {
+                var timestamp = httpContext.Timestamp;
+                if (timestamp > DateTime.MinValue)
+                {
+                    var currentDuration = DateTime.UtcNow - timestamp.ToUniversalTime();
+                    if (currentDuration > TimeSpan.FromMilliseconds(DurationThresholdMs))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private bool IsExcludedHttpRequest(HttpContext httpContext)
+        {
+            if (ExcludeRequestPaths.Count > 0)
+            {
+                var requestPath = httpContext.Request?.Url?.AbsolutePath;
+                if (string.IsNullOrEmpty(requestPath))
+                {
+                    return false;
+                }
+
+                return ExcludeRequestPaths.Contains(requestPath);
+            }
+
+            return false;
         }
     }
 }

--- a/src/Shared/Layouts/W3CExtendedLogField.cs
+++ b/src/Shared/Layouts/W3CExtendedLogField.cs
@@ -43,6 +43,7 @@ namespace NLog.Web.Layouts
         ///  * sc- = server to client response details<br/>
         /// </remarks>
         /// <docgen category='W3C Field Options' order='10' />
+        [RequiredParameter]
         public string Name { get; set; }
 
         /// <summary>


### PR DESCRIPTION
Alternative one can use when-filters in the NLog LoggingRules, but ExcludeRequestPaths is faster