### PR TITLE
ASP.NET Response Cookie Layout Renderer

### DIFF
--- a/src/NLog.Web.AspNetCore/NLog.Web.AspNetCore.csproj
+++ b/src/NLog.Web.AspNetCore/NLog.Web.AspNetCore.csproj
@@ -75,15 +75,14 @@ NLog 5 release post: https://nlog-project.org/2021/08/25/nlog-5-0-preview1-ready
     <DefineConstants>$(DefineConstants);ASP_NET_CORE;ASP_NET_CORE3</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.1.21" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="5.0.0" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />
+	  <PackageReference Include="NLog.Extensions.Logging" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net461' ">
     <!-- Fixed to 2.1.0 as 2.1 is Long Term Supported (LTS) and works with vanilla .NET Core 2.1 SDK -->
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.22" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="2.1.0" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />

--- a/src/NLog.Web.AspNetCore/NLog.Web.AspNetCore.csproj
+++ b/src/NLog.Web.AspNetCore/NLog.Web.AspNetCore.csproj
@@ -77,13 +77,13 @@ NLog 5 release post: https://nlog-project.org/2021/08/25/nlog-5-0-preview1-ready
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.1.21" />
     <PackageReference Include="NLog.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net461' ">
     <!-- Fixed to 2.1.0 as 2.1 is Long Term Supported (LTS) and works with vanilla .NET Core 2.1 SDK -->
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.22" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="2.1.0" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />

--- a/src/NLog.Web.AspNetCore/NLog.Web.AspNetCore.csproj
+++ b/src/NLog.Web.AspNetCore/NLog.Web.AspNetCore.csproj
@@ -75,11 +75,12 @@ NLog 5 release post: https://nlog-project.org/2021/08/25/nlog-5-0-preview1-ready
     <DefineConstants>$(DefineConstants);ASP_NET_CORE;ASP_NET_CORE3</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-	<PackageReference Include="NLog.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net461' ">
     <!-- Fixed to 2.1.0 as 2.1 is Long Term Supported (LTS) and works with vanilla .NET Core 2.1 SDK -->
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.22" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.1.21" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="2.1.0" />
     <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />

--- a/src/NLog.Web.AspNetCore/NLog.Web.AspNetCore.csproj
+++ b/src/NLog.Web.AspNetCore/NLog.Web.AspNetCore.csproj
@@ -75,12 +75,11 @@ NLog 5 release post: https://nlog-project.org/2021/08/25/nlog-5-0-preview1-ready
     <DefineConstants>$(DefineConstants);ASP_NET_CORE;ASP_NET_CORE3</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NLog.Extensions.Logging" Version="5.0.0" />
+	<PackageReference Include="NLog.Extensions.Logging" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net461' ">
     <!-- Fixed to 2.1.0 as 2.1 is Long Term Supported (LTS) and works with vanilla .NET Core 2.1 SDK -->
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.22" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.1.21" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="2.1.0" />
     <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />

--- a/src/NLog.Web.AspNetCore/NLog.Web.AspNetCore.csproj
+++ b/src/NLog.Web.AspNetCore/NLog.Web.AspNetCore.csproj
@@ -75,7 +75,7 @@ NLog 5 release post: https://nlog-project.org/2021/08/25/nlog-5-0-preview1-ready
     <DefineConstants>$(DefineConstants);ASP_NET_CORE;ASP_NET_CORE3</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-	  <PackageReference Include="NLog.Extensions.Logging" Version="5.0.0" />
+	<PackageReference Include="NLog.Extensions.Logging" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net461' ">
     <!-- Fixed to 2.1.0 as 2.1 is Long Term Supported (LTS) and works with vanilla .NET Core 2.1 SDK -->

--- a/src/NLog.Web.AspNetCore/NLog.Web.AspNetCore.csproj
+++ b/src/NLog.Web.AspNetCore/NLog.Web.AspNetCore.csproj
@@ -75,6 +75,7 @@ NLog 5 release post: https://nlog-project.org/2021/08/25/nlog-5-0-preview1-ready
     <DefineConstants>$(DefineConstants);ASP_NET_CORE;ASP_NET_CORE3</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.1.21" />
     <PackageReference Include="NLog.Extensions.Logging" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net461' ">

--- a/src/Shared/Internal/HttpContextExtensions.cs
+++ b/src/Shared/Internal/HttpContextExtensions.cs
@@ -67,6 +67,43 @@ namespace NLog.Web.Internal
         }
 #endif
 
+#if ASP_NET_CORE2
+        internal static string GetString(this ISession session, string key)
+        {
+            if (!session.TryGetValue(key, out var data))
+            {
+                return null;
+            }
+
+            if (data == null)
+            {
+                return null;
+            }
+
+            if (data.Length == 0)
+            {
+                return string.Empty;
+            }
+
+            return Encoding.UTF8.GetString(data);
+        }
+
+        public static int? GetInt32(this ISession session, string key)
+        {
+            if (!session.TryGetValue(key, out var data))
+            {
+                return null;
+            }
+
+            if (data == null || data.Length < 4)
+            {
+                return null;
+            }
+            return data[0] << 24 | data[1] << 16 | data[2] << 8 | data[3];
+        }
+#endif
+
+
 #if !ASP_NET_CORE
         internal static HttpSessionStateBase TryGetSession(this HttpContextBase context)
         {

--- a/src/Shared/Internal/HttpContextExtensions.cs
+++ b/src/Shared/Internal/HttpContextExtensions.cs
@@ -5,11 +5,6 @@ using System.Web;
 using System.Text;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
-
-#if! ASP_NET_CORE2
-using Microsoft.AspNetCore.Http.Headers;
-#endif
-
 #endif
 using NLog.Common;
 

--- a/src/Shared/Internal/HttpContextExtensions.cs
+++ b/src/Shared/Internal/HttpContextExtensions.cs
@@ -62,42 +62,6 @@ namespace NLog.Web.Internal
         }
 #endif
 
-#if ASP_NET_CORE2
-        internal static string GetString(this ISession session, string key)
-        {
-            if (!session.TryGetValue(key, out var data))
-            {
-                return null;
-            }
-
-            if (data == null)
-            {
-                return null;
-            }
-
-            if (data.Length == 0)
-            {
-                return string.Empty;
-            }
-
-            return Encoding.UTF8.GetString(data);
-        }
-
-        public static int? GetInt32(this ISession session, string key)
-        {
-            if (!session.TryGetValue(key, out var data))
-            {
-                return null;
-            }
-
-            if (data == null || data.Length < 4)
-            {
-                return null;
-            }
-            return data[0] << 24 | data[1] << 16 | data[2] << 8 | data[3];
-        }
-#endif
-
 #if !ASP_NET_CORE
         internal static HttpSessionStateBase TryGetSession(this HttpContextBase context)
         {

--- a/src/Shared/Internal/HttpContextExtensions.cs
+++ b/src/Shared/Internal/HttpContextExtensions.cs
@@ -98,7 +98,6 @@ namespace NLog.Web.Internal
         }
 #endif
 
-
 #if !ASP_NET_CORE
         internal static HttpSessionStateBase TryGetSession(this HttpContextBase context)
         {

--- a/src/Shared/Internal/HttpContextExtensions.cs
+++ b/src/Shared/Internal/HttpContextExtensions.cs
@@ -67,43 +67,6 @@ namespace NLog.Web.Internal
         }
 #endif
 
-#if ASP_NET_CORE2
-        internal static string GetString(this ISession session, string key)
-        {
-            if (!session.TryGetValue(key, out var data))
-            {
-                return null;
-            }
-
-            if (data == null)
-            {
-                return null;
-            }
-
-            if (data.Length == 0)
-            {
-                return string.Empty;
-            }
-
-            return Encoding.UTF8.GetString(data);
-        }
-
-        public static int? GetInt32(this ISession session, string key)
-        {
-            if (!session.TryGetValue(key, out var data))
-            {
-                return null;
-            }
-
-            if (data == null || data.Length < 4)
-            {
-                return null;
-            }
-            return data[0] << 24 | data[1] << 16 | data[2] << 8 | data[3];
-        }
-#endif
-
-
 #if !ASP_NET_CORE
         internal static HttpSessionStateBase TryGetSession(this HttpContextBase context)
         {

--- a/src/Shared/Internal/HttpContextExtensions.cs
+++ b/src/Shared/Internal/HttpContextExtensions.cs
@@ -5,6 +5,11 @@ using System.Web;
 using System.Text;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
+
+#if! ASP_NET_CORE2
+using Microsoft.AspNetCore.Http.Headers;
+#endif
+
 #endif
 using NLog.Common;
 
@@ -61,6 +66,43 @@ namespace NLog.Web.Internal
             return response;
         }
 #endif
+
+#if ASP_NET_CORE2
+        internal static string GetString(this ISession session, string key)
+        {
+            if (!session.TryGetValue(key, out var data))
+            {
+                return null;
+            }
+
+            if (data == null)
+            {
+                return null;
+            }
+
+            if (data.Length == 0)
+            {
+                return string.Empty;
+            }
+
+            return Encoding.UTF8.GetString(data);
+        }
+
+        public static int? GetInt32(this ISession session, string key)
+        {
+            if (!session.TryGetValue(key, out var data))
+            {
+                return null;
+            }
+
+            if (data == null || data.Length < 4)
+            {
+                return null;
+            }
+            return data[0] << 24 | data[1] << 16 | data[2] << 8 | data[3];
+        }
+#endif
+
 
 #if !ASP_NET_CORE
         internal static HttpSessionStateBase TryGetSession(this HttpContextBase context)

--- a/src/Shared/Internal/HttpContextExtensions.cs
+++ b/src/Shared/Internal/HttpContextExtensions.cs
@@ -5,6 +5,11 @@ using System.Web;
 using System.Text;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
+
+#if! ASP_NET_CORE2
+using Microsoft.AspNetCore.Http.Headers;
+#endif
+
 #endif
 using NLog.Common;
 

--- a/src/Shared/LayoutRenderers/AspNetResponseCookieLayoutRenderer.cs
+++ b/src/Shared/LayoutRenderers/AspNetResponseCookieLayoutRenderer.cs
@@ -116,25 +116,31 @@ namespace NLog.Web.LayoutRenderers
                     continue;
                 }
 
-                if (OutputFormat != AspNetRequestLayoutOutputFormat.Flat)
+                return GetCookieValue(httpCookie, cookieName);
+            }
+            return new List<KeyValuePair<string, string>>();
+        }
+
+        private IEnumerable<KeyValuePair<string, string>> GetCookieValue(HttpCookie httpCookie, string cookieName)
+        {
+            if (OutputFormat != AspNetRequestLayoutOutputFormat.Flat)
+            {
+                // Split multi-valued cookie, as allowed for in the HttpCookie API for backwards compatibility with classic ASP
+                var isFirst = true;
+                foreach (var multiValueKey in httpCookie.Values.AllKeys)
                 {
-                    // Split multi-valued cookie, as allowed for in the HttpCookie API for backwards compatibility with classic ASP
-                    var isFirst = true;
-                    foreach (var multiValueKey in httpCookie.Values.AllKeys)
+                    var cookieKey = multiValueKey;
+                    if (isFirst)
                     {
-                        var cookieKey = multiValueKey;
-                        if (isFirst)
-                        {
-                            cookieKey = cookieName;
-                            isFirst = false;
-                        }
-                        yield return new KeyValuePair<string, string>(cookieKey, httpCookie.Values[multiValueKey]);
+                        cookieKey = cookieName;
+                        isFirst = false;
                     }
+                    yield return new KeyValuePair<string, string>(cookieKey, httpCookie.Values[multiValueKey]);
                 }
-                else
-                {
-                    yield return new KeyValuePair<string, string>(cookieName, httpCookie.Value);
-                }
+            }
+            else
+            {
+                yield return new KeyValuePair<string, string>(cookieName, httpCookie.Value);
             }
         }
 

--- a/src/Shared/LayoutRenderers/AspNetResponseCookieLayoutRenderer.cs
+++ b/src/Shared/LayoutRenderers/AspNetResponseCookieLayoutRenderer.cs
@@ -168,13 +168,16 @@ namespace NLog.Web.LayoutRenderers
                 if (checkForExclude && Exclude.Contains(cookieName))
                     continue;
 
-                var httpCookie = cookies.SingleOrDefault(cookie => cookie.Name.ToString() == cookieName);
-                if (httpCookie == null)
+                var httpCookies = cookies.Where(cookie => cookie.Name.ToString() == cookieName).ToList();
+                if (!httpCookies.Any())
                 {
                     continue;
                 }
 
-                yield return new KeyValuePair<string, string>(cookieName, httpCookie.Value.ToString());
+                foreach (var cookie in cookies)
+                {
+                    yield return new KeyValuePair<string, string>(cookieName, cookie.Value.ToString());
+                }
             }
         }
 #endif

--- a/src/Shared/LayoutRenderers/AspNetResponseCookieLayoutRenderer.cs
+++ b/src/Shared/LayoutRenderers/AspNetResponseCookieLayoutRenderer.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Sockets;
 using System.Text;
-using NLog.Config;
 using NLog.LayoutRenderers;
 using NLog.Web.Enums;
 using NLog.Web.Internal;
@@ -74,7 +72,7 @@ namespace NLog.Web.LayoutRenderers
 
             var cookies = GetCookies(httpResponse);
 #if ASP_NET_CORE
-            if (cookies.Any())
+            if (cookies.Count > 0)
 #else
             if(cookies.Count > 0)
 #endif

--- a/src/Shared/LayoutRenderers/AspNetResponseCookieLayoutRenderer.cs
+++ b/src/Shared/LayoutRenderers/AspNetResponseCookieLayoutRenderer.cs
@@ -138,7 +138,29 @@ namespace NLog.Web.LayoutRenderers
             }
         }
 
-#else
+#elif ASP_NET_CORE2
+
+        /// <summary>
+        /// Method to wrap getting cookies from the HTTP Response for both Framework and Core
+        /// </summary>
+        /// <param name="response"></param>
+        /// <returns></returns>
+        protected IEnumerable<SetCookieHeaderValue> GetCookies(HttpResponse response)
+        {
+            var queryResults = response.Headers.Where(row => row.Key == HeaderNames.SetCookie).ToList();
+            foreach (KeyValuePair<string, StringValues> row in queryResults)
+            {
+                string[] cookieList = row.Value.ToString().Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                foreach (var cookie in cookieList)
+                {
+                    SetCookieHeaderValue.TryParse(new StringSegment(cookie), out SetCookieHeaderValue parsed);
+                    yield return parsed;
+                }
+            }
+        }
+
+
+#elif ASP_NET_CORE3
         /// <summary>
         /// Method to wrap getting cookies from the HTTP Response for both Framework and Core
         /// </summary>
@@ -148,7 +170,9 @@ namespace NLog.Web.LayoutRenderers
         {
             return response.GetTypedHeaders().SetCookie;
         }
+#endif
 
+#if ASP_NET_CORE
         private List<string> GetCookieNames(IEnumerable<SetCookieHeaderValue> cookies)
         {
             return CookieNames?.Count > 0 ? CookieNames : cookies.Select(row => row.Name.ToString()).ToList();

--- a/src/Shared/LayoutRenderers/AspNetResponseCookieLayoutRenderer.cs
+++ b/src/Shared/LayoutRenderers/AspNetResponseCookieLayoutRenderer.cs
@@ -1,0 +1,185 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NLog.Config;
+using NLog.LayoutRenderers;
+using NLog.Web.Enums;
+using NLog.Web.Internal;
+#if !ASP_NET_CORE
+using System.Collections.Specialized;
+using System.Web;
+using Cookies = System.Web.HttpCookieCollection;
+#else
+using Microsoft.Net.Http.Headers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Extensions;
+#endif
+
+namespace NLog.Web.LayoutRenderers
+{
+    /// <summary>
+    /// ASP.NET Response Cookie
+    /// </summary>
+    /// <example>
+    /// <para>Example usage of ${aspnet-response-cookie}</para>
+    /// <code lang="NLog Layout Renderer">
+    /// ${aspnet-response-cookie:OutputFormat=Flat}
+    /// ${aspnet-response-cookie:OutputFormat=JsonArray}
+    /// ${aspnet-response-cookie:OutputFormat=JsonDictionary}
+    /// ${aspnet-response-cookie:OutputFormat=JsonDictionary:CookieNames=username}
+    /// ${aspnet-response-cookie:OutputFormat=JsonDictionary:Exclude=access_token}
+    /// </code>
+    /// </example>
+    [LayoutRenderer("aspnet-response-cookie")]
+    public class AspNetResponseCookieLayoutRenderer : AspNetLayoutMultiValueRendererBase
+    {
+        /// <summary>
+        /// Cookie names to be rendered.
+        /// If <c>null</c> or empty array, all cookies will be rendered.
+        /// </summary>
+        public List<string> CookieNames { get; set; }
+
+        /// <summary>
+        /// Gets or sets the keys to exclude from the output. If omitted, none are excluded.
+        /// </summary>
+        /// <docgen category='Rendering Options' order='10' />
+#if ASP_NET_CORE
+        public ISet<string> Exclude { get; set; }
+#else
+        public HashSet<string> Exclude { get; set; }
+#endif
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AspNetResponseCookieLayoutRenderer" /> class.
+        /// </summary>
+        public AspNetResponseCookieLayoutRenderer()
+        {
+            Exclude = new HashSet<string>(new[] { "AUTH", "SESS_ID" }, StringComparer.OrdinalIgnoreCase);
+        }
+
+#if !ASP_NET_CORE
+        /// <summary>
+        /// Renders the ASP.NET Cookie appends it to the specified <see cref="StringBuilder" />.
+        /// </summary>
+        /// <param name="builder">The <see cref="StringBuilder" /> to append the rendered data to.</param>
+        /// <param name="logEvent">Logging event.</param>
+        protected override void DoAppend(StringBuilder builder, LogEventInfo logEvent)
+        {
+            var httpResponse = HttpContextAccessor.HttpContext.TryGetResponse();
+            if (httpResponse == null)
+            {
+                return;
+            }
+
+            var cookies = httpResponse.Cookies;
+
+            if (cookies?.Count > 0)
+            {
+                bool checkForExclude = (CookieNames == null || CookieNames.Count == 0) && Exclude?.Count > 0;
+                var cookieValues = GetCookieValues(cookies, checkForExclude);
+                SerializePairs(cookieValues, builder, logEvent);
+            }
+        }
+
+        private IEnumerable<KeyValuePair<string, string>> GetCookieValues(HttpCookieCollection cookies, bool checkForExclude)
+        {
+            var cookieNames = GetCookieNames(cookies);
+            foreach (var cookieName in cookieNames)
+            {
+                if (checkForExclude && Exclude.Contains(cookieName))
+                    continue;
+
+                var httpCookie = cookies[cookieName];
+                if (httpCookie == null)
+                {
+                    continue;
+                }
+
+                if (OutputFormat != AspNetRequestLayoutOutputFormat.Flat)
+                {
+                    // Split multi-valued cookie, as allowed for in the HttpCookie API for backwards compatibility with classic ASP
+                    var isFirst = true;
+                    foreach (var multiValueKey in httpCookie.Values.AllKeys)
+                    {
+                        var cookieKey = multiValueKey;
+                        if (isFirst)
+                        {
+                            cookieKey = cookieName;
+                            isFirst = false;
+                        }
+                        yield return new KeyValuePair<string, string>(cookieKey, httpCookie.Values[multiValueKey]);
+                    }
+                }
+                else
+                {
+                    yield return new KeyValuePair<string, string>(cookieName, httpCookie.Value);
+                }
+            }
+        }
+
+        private List<string> GetCookieNames(HttpCookieCollection cookies)
+        {
+            return CookieNames?.Count > 0 ? CookieNames : cookies.Keys.Cast<string>().ToList();
+        }
+#else
+        /// <summary>
+        /// Renders the ASP.NET Cookie appends it to the specified <see cref="StringBuilder" />.
+        /// </summary>
+        /// <param name="builder">The <see cref="StringBuilder" /> to append the rendered data to.</param>
+        /// <param name="logEvent">Logging event.</param>
+        protected override void DoAppend(StringBuilder builder, LogEventInfo logEvent)
+        {
+            var httpResponse = HttpContextAccessor.HttpContext.TryGetResponse();
+            if (httpResponse == null)
+            {
+                return;
+            }
+
+            IList<SetCookieHeaderValue> cookies = httpResponse.GetTypedHeaders().SetCookie;
+
+            if (cookies?.Count > 0)
+            {
+                bool checkForExclude = (CookieNames == null || CookieNames.Count == 0) && Exclude?.Count > 0;
+                var cookieValues = GetCookieValues(cookies, checkForExclude);
+                SerializePairs(cookieValues, builder, logEvent);
+            }
+        }
+
+        private List<string> GetCookieNames(IList<SetCookieHeaderValue> cookies)
+        {
+            if (CookieNames?.Count > 0)
+            {
+                return CookieNames;
+            }
+
+            var response = new List<string>();
+
+            foreach (var cookie in cookies)
+            {
+                response.Add(cookie.Name.ToString());
+            }
+
+            return response;
+        }
+
+        private IEnumerable<KeyValuePair<string, string>> GetCookieValues(IList<SetCookieHeaderValue> cookies, bool checkForExclude)
+        {
+            var cookieNames = GetCookieNames(cookies);
+            foreach (var cookieName in cookieNames)
+            {
+                if (checkForExclude && Exclude.Contains(cookieName))
+                    continue;
+
+                var httpCookie = cookies.SingleOrDefault(cookie => cookie.Name.ToString() == cookieName);
+                if (httpCookie == null)
+                {
+                    continue;
+                }
+
+                yield return new KeyValuePair<string, string>(cookieName, httpCookie.Value.ToString());
+            }
+        }
+#endif
+    }
+}

--- a/src/Shared/LayoutRenderers/AspNetResponseCookieLayoutRenderer.cs
+++ b/src/Shared/LayoutRenderers/AspNetResponseCookieLayoutRenderer.cs
@@ -166,7 +166,7 @@ namespace NLog.Web.LayoutRenderers
         /// </summary>
         /// <param name="response"></param>
         /// <returns></returns>
-        protected IEnumerable<SetCookieHeaderValue> GetCookies(HttpResponse response)
+        protected static IEnumerable<SetCookieHeaderValue> GetCookies(HttpResponse response)
         {
             return response.GetTypedHeaders().SetCookie;
         }

--- a/src/Shared/LayoutRenderers/AspNetResponseCookieLayoutRenderer.cs
+++ b/src/Shared/LayoutRenderers/AspNetResponseCookieLayoutRenderer.cs
@@ -116,31 +116,25 @@ namespace NLog.Web.LayoutRenderers
                     continue;
                 }
 
-                return GetCookieValue(httpCookie, cookieName);
-            }
-            return new List<KeyValuePair<string, string>>();
-        }
-
-        private IEnumerable<KeyValuePair<string, string>> GetCookieValue(HttpCookie httpCookie, string cookieName)
-        {
-            if (OutputFormat != AspNetRequestLayoutOutputFormat.Flat)
-            {
-                // Split multi-valued cookie, as allowed for in the HttpCookie API for backwards compatibility with classic ASP
-                var isFirst = true;
-                foreach (var multiValueKey in httpCookie.Values.AllKeys)
+                if (OutputFormat != AspNetRequestLayoutOutputFormat.Flat)
                 {
-                    var cookieKey = multiValueKey;
-                    if (isFirst)
+                    // Split multi-valued cookie, as allowed for in the HttpCookie API for backwards compatibility with classic ASP
+                    var isFirst = true;
+                    foreach (var multiValueKey in httpCookie.Values.AllKeys)
                     {
-                        cookieKey = cookieName;
-                        isFirst = false;
+                        var cookieKey = multiValueKey;
+                        if (isFirst)
+                        {
+                            cookieKey = cookieName;
+                            isFirst = false;
+                        }
+                        yield return new KeyValuePair<string, string>(cookieKey, httpCookie.Values[multiValueKey]);
                     }
-                    yield return new KeyValuePair<string, string>(cookieKey, httpCookie.Values[multiValueKey]);
                 }
-            }
-            else
-            {
-                yield return new KeyValuePair<string, string>(cookieName, httpCookie.Value);
+                else
+                {
+                    yield return new KeyValuePair<string, string>(cookieName, httpCookie.Value);
+                }
             }
         }
 

--- a/src/Shared/LayoutRenderers/AspNetResponseCookieLayoutRenderer.cs
+++ b/src/Shared/LayoutRenderers/AspNetResponseCookieLayoutRenderer.cs
@@ -71,11 +71,7 @@ namespace NLog.Web.LayoutRenderers
             }
 
             var cookies = GetCookies(httpResponse);
-#if ASP_NET_CORE
             if (cookies.Count > 0)
-#else
-            if(cookies.Count > 0)
-#endif
             {
                 bool checkForExclude = (CookieNames == null || CookieNames.Count == 0) && Exclude?.Count > 0;
                 var cookieValues = GetCookieValues(cookies, checkForExclude);

--- a/src/Shared/LayoutRenderers/AspNetResponseCookieLayoutRenderer.cs
+++ b/src/Shared/LayoutRenderers/AspNetResponseCookieLayoutRenderer.cs
@@ -138,29 +138,7 @@ namespace NLog.Web.LayoutRenderers
             }
         }
 
-#elif ASP_NET_CORE2
-
-        /// <summary>
-        /// Method to wrap getting cookies from the HTTP Response for both Framework and Core
-        /// </summary>
-        /// <param name="response"></param>
-        /// <returns></returns>
-        protected IEnumerable<SetCookieHeaderValue> GetCookies(HttpResponse response)
-        {
-            var queryResults = response.Headers.Where(row => row.Key == HeaderNames.SetCookie).ToList();
-            foreach (KeyValuePair<string, StringValues> row in queryResults)
-            {
-                string[] cookieList = row.Value.ToString().Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
-                foreach (var cookie in cookieList)
-                {
-                    SetCookieHeaderValue.TryParse(new StringSegment(cookie), out SetCookieHeaderValue parsed);
-                    yield return parsed;
-                }
-            }
-        }
-
-
-#elif ASP_NET_CORE3
+#else
         /// <summary>
         /// Method to wrap getting cookies from the HTTP Response for both Framework and Core
         /// </summary>
@@ -170,9 +148,7 @@ namespace NLog.Web.LayoutRenderers
         {
             return response.GetTypedHeaders().SetCookie;
         }
-#endif
 
-#if ASP_NET_CORE
         private List<string> GetCookieNames(IEnumerable<SetCookieHeaderValue> cookies)
         {
             return CookieNames?.Count > 0 ? CookieNames : cookies.Select(row => row.Name.ToString()).ToList();

--- a/src/Shared/LayoutRenderers/AspNetResponseCookieLayoutRenderer.cs
+++ b/src/Shared/LayoutRenderers/AspNetResponseCookieLayoutRenderer.cs
@@ -168,16 +168,13 @@ namespace NLog.Web.LayoutRenderers
                 if (checkForExclude && Exclude.Contains(cookieName))
                     continue;
 
-                var httpCookies = cookies.Where(cookie => cookie.Name.ToString() == cookieName).ToList();
-                if (!httpCookies.Any())
+                var httpCookie = cookies.SingleOrDefault(cookie => cookie.Name.ToString() == cookieName);
+                if (httpCookie == null)
                 {
                     continue;
                 }
 
-                foreach (var cookie in cookies)
-                {
-                    yield return new KeyValuePair<string, string>(cookieName, cookie.Value.ToString());
-                }
+                yield return new KeyValuePair<string, string>(cookieName, httpCookie.Value.ToString());
             }
         }
 #endif

--- a/src/Shared/LayoutRenderers/AspNetResponseCookieLayoutRenderer.cs
+++ b/src/Shared/LayoutRenderers/AspNetResponseCookieLayoutRenderer.cs
@@ -86,7 +86,7 @@ namespace NLog.Web.LayoutRenderers
         /// </summary>
         /// <param name="response"></param>
         /// <returns></returns>
-        protected Cookies GetCookies(HttpResponseBase response)
+        private Cookies GetCookies(HttpResponseBase response)
         {
             return response.Cookies;
         }
@@ -144,7 +144,7 @@ namespace NLog.Web.LayoutRenderers
         /// </summary>
         /// <param name="response"></param>
         /// <returns></returns>
-        protected static IList<SetCookieHeaderValue> GetCookies(HttpResponse response)
+        private static IList<SetCookieHeaderValue> GetCookies(HttpResponse response)
         {
             var queryResults = response.Headers[HeaderNames.SetCookie];
             if (queryResults.Count > 0 && SetCookieHeaderValue.TryParseList(queryResults, out var result))

--- a/tests/Shared/LayoutRenderers/AspNetResponseCookieLayoutRendererTests.cs
+++ b/tests/Shared/LayoutRenderers/AspNetResponseCookieLayoutRendererTests.cs
@@ -1,0 +1,434 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NLog.Web.LayoutRenderers;
+using NLog.Web.Enums;
+using Xunit;
+#if !ASP_NET_CORE
+using NSubstitute;
+using System.Web;
+#else
+using Microsoft.Extensions.Primitives;
+#endif
+
+namespace NLog.Web.Tests.LayoutRenderers
+{
+    public class AspNetResponseCookieLayoutRendererTests : TestInvolvingAspNetHttpContext
+    {
+        [Fact]
+        public void NullKeyRendersAllCookies()
+        {
+            var expectedResult = "key=TEST,Key1=TEST1";
+            var renderer = CreateRenderer();
+            renderer.CookieNames = null;
+
+            string result = renderer.Render(new LogEventInfo());
+
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public void NullKeyRendersAllCookiesExceptExcluded()
+        {
+            var expectedResult = "Key1=TEST1";
+            var renderer = CreateRenderer();
+            renderer.CookieNames = null;
+            renderer.Exclude.Add("key");
+
+            string result = renderer.Render(new LogEventInfo());
+
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public void KeyNotFoundRendersEmptyString_Flat_Formatting()
+        {
+            var renderer = CreateRenderer();
+            renderer.OutputFormat = AspNetRequestLayoutOutputFormat.Flat;
+            renderer.CookieNames = new List<string> { "notfound" };
+
+            string result = renderer.Render(new LogEventInfo());
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void KeyNotFoundRendersEmptyString_Json_Formatting()
+        {
+            var renderer = CreateRenderer();
+            renderer.OutputFormat = AspNetRequestLayoutOutputFormat.JsonArray;
+            renderer.CookieNames = new List<string> { "notfound" };
+
+            string result = renderer.Render(new LogEventInfo());
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void KeyFoundRendersValue_Multiple_Cookies_Flat_Formatting()
+        {
+            var expectedResult = "key=TEST,Key1=TEST1";
+
+            var renderer = CreateRenderer();
+
+            string result = renderer.Render(new LogEventInfo());
+
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public void KeyFoundRendersValue_Multiple_Cookies_Flat_Formatting_separators()
+        {
+            var expectedResult = "key:TEST|Key1:TEST1";
+
+            var renderer = CreateRenderer();
+            renderer.ValueSeparator = ":";
+            renderer.ItemSeparator = "|";
+
+            string result = renderer.Render(new LogEventInfo());
+
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public void KeyFoundRendersValue_Multiple_Cookies_Flat_Formatting_separators_layouts()
+        {
+            var expectedResult = "key>TEST" + Environment.NewLine + "Key1>TEST1";
+
+            var renderer = CreateRenderer();
+            renderer.ValueSeparator = "${event-properties:valueSeparator1}";
+            renderer.ItemSeparator = "${newline}";
+
+            var logEventInfo = new LogEventInfo();
+            logEventInfo.Properties["valueSeparator1"] = ">";
+
+            // Act
+            string result = renderer.Render(logEventInfo);
+
+            // Assert
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public void KeyFoundRendersValue_Single_Cookie_Flat_Formatting()
+        {
+            var expectedResult = "key=TEST";
+
+            var renderer = CreateRenderer(addSecondCookie: false);
+
+            string result = renderer.Render(new LogEventInfo());
+
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public void KeyFoundRendersValue_Single_Cookie_Json_Formatting()
+        {
+            var expectedResult = "[{\"key\":\"TEST\"}]";
+
+            var renderer = CreateRenderer(addSecondCookie: false);
+            renderer.OutputFormat = AspNetRequestLayoutOutputFormat.JsonArray;
+
+            string result = renderer.Render(new LogEventInfo());
+
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public void KeyFoundRendersValue_Single_Cookie_Json_Formatting_no_array()
+        {
+            var expectedResult = "{\"key\":\"TEST\"}";
+
+            var renderer = CreateRenderer(addSecondCookie: false);
+            renderer.OutputFormat = AspNetRequestLayoutOutputFormat.JsonDictionary;
+
+            string result = renderer.Render(new LogEventInfo());
+
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public void KeyFoundRendersValue_Multiple_Cookies_Json_Formatting()
+        {
+            var expectedResult = "[{\"key\":\"TEST\"},{\"Key1\":\"TEST1\"}]";
+
+            var renderer = CreateRenderer();
+            renderer.OutputFormat = AspNetRequestLayoutOutputFormat.JsonArray;
+
+            string result = renderer.Render(new LogEventInfo());
+
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public void KeyFoundRendersValue_Multiple_Cookies_Json_Formatting_no_array()
+        {
+            var expectedResult = "{\"key\":\"TEST\",\"Key1\":\"TEST1\"}";
+
+            var renderer = CreateRenderer();
+            renderer.OutputFormat = AspNetRequestLayoutOutputFormat.JsonDictionary;
+
+            string result = renderer.Render(new LogEventInfo());
+
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public void KeyNotFoundRendersEmptyString_Flat_Formatting_ValuesOnly()
+        {
+            var renderer = CreateRenderer();
+            renderer.OutputFormat = AspNetRequestLayoutOutputFormat.Flat;
+            renderer.CookieNames = new List<string> { "notfound" };
+            renderer.ValuesOnly = true;
+
+            string result = renderer.Render(new LogEventInfo());
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void KeyNotFoundRendersEmptyString_Json_Formatting_ValuesOnly()
+        {
+            var renderer = CreateRenderer();
+            renderer.OutputFormat = AspNetRequestLayoutOutputFormat.JsonArray;
+            renderer.CookieNames = new List<string> { "notfound" };
+            renderer.ValuesOnly = true;
+
+            string result = renderer.Render(new LogEventInfo());
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void KeyFoundRendersValue_Cookie_Multiple_Items_Flat_Formatting_ValuesOnly()
+        {
+            var expectedResult = "TEST,TEST1";
+
+            var renderer = CreateRenderer();
+            renderer.ValuesOnly = true;
+
+            string result = renderer.Render(new LogEventInfo());
+
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public void KeyFoundRendersValue_Cookie_Multiple_Items_Flat_Formatting_separators_ValuesOnly()
+        {
+            var expectedResult = "TEST|TEST1";
+
+            var renderer = CreateRenderer();
+            renderer.ValueSeparator = ":";
+            renderer.ItemSeparator = "|";
+            renderer.ValuesOnly = true;
+
+            string result = renderer.Render(new LogEventInfo());
+
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public void KeyFoundRendersValue_Single_Item_Flat_Formatting_ValuesOnly()
+        {
+            var expectedResult = "TEST";
+
+            var renderer = CreateRenderer(addSecondCookie: false);
+            renderer.ValuesOnly = true;
+
+            string result = renderer.Render(new LogEventInfo());
+
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Theory]
+        [InlineData(AspNetRequestLayoutOutputFormat.JsonArray)]
+        [InlineData(AspNetRequestLayoutOutputFormat.JsonDictionary)]
+        public void KeyFoundRendersValue_Single_Item_JsonArray_Formatting_ValuesOnly(AspNetRequestLayoutOutputFormat outputFormat)
+        {
+            var expectedResult = "[\"TEST\"]";
+
+            var renderer = CreateRenderer(addSecondCookie: false);
+            renderer.OutputFormat = outputFormat;
+            renderer.ValuesOnly = true;
+
+            string result = renderer.Render(new LogEventInfo());
+
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Theory]
+        [InlineData(AspNetRequestLayoutOutputFormat.JsonArray)]
+        [InlineData(AspNetRequestLayoutOutputFormat.JsonDictionary)]
+        public void KeyFoundRendersValue_Multiple_Items_Json_Formatting_ValuesOnly(AspNetRequestLayoutOutputFormat outputFormat)
+        {
+            var expectedResult = "[\"TEST\",\"TEST1\"]";
+
+            var renderer = CreateRenderer();
+
+            renderer.OutputFormat = outputFormat;
+            renderer.ValuesOnly = true;
+
+            string result = renderer.Render(new LogEventInfo());
+
+            Assert.Equal(expectedResult, result);
+        }
+
+        //no multivalue cookie keys in ASP.NET core
+#if !ASP_NET_CORE
+
+        [Fact]
+        public void KeyFoundRendersValue_Multiple_Cookies_And_Cookie_Values_Flat_Formatting()
+        {
+            var expectedResult = "key=TEST,key2=Test&key3=Test456";
+
+            var renderer = CreateRenderer(addSecondCookie: true, addMultiValueCookieKey: true);
+            renderer.CookieNames = new List<string> { "key", "key2" };
+
+            string result = renderer.Render(new LogEventInfo());
+
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public void KeyFoundRendersValue_Multiple_Cookies_And_Cookie_Values_Json_Formatting()
+        {
+            var expectedResult = "[{\"key\":\"TEST\"},{\"Key1\":\"TEST1\"},{\"key2\":\"Test\"},{\"key3\":\"Test456\"}]";
+            var renderer = CreateRenderer(addSecondCookie: true, addMultiValueCookieKey: true);
+            renderer.OutputFormat = AspNetRequestLayoutOutputFormat.JsonArray;
+
+            string result = renderer.Render(new LogEventInfo());
+
+            Assert.Equal(expectedResult, result);
+        }
+#endif
+
+#if !ASP_NET_CORE //todo
+
+        [Fact]
+        public void CommaSeperatedCookieNamesTest_Multiple_Cookie_Values_Flat_Formatting()
+        {
+            // Arrange
+            var expectedResult = "key=TEST&Key1=TEST1";
+
+            var cookie = new HttpCookie("key", "TEST") { ["Key1"] = "TEST1" };
+
+            var layoutRender = new AspNetRequestCookieLayoutRenderer()
+            {
+                CookieNames = new List<string> { "key", "key1" }
+            };
+
+            var httpContextAccessorMock = CreateHttpContextAccessorMockWithCookie(cookie);
+            layoutRender.HttpContextAccessor = httpContextAccessorMock;
+
+            // Act
+            var result = layoutRender.Render(LogEventInfo.CreateNullEvent());
+
+            // Assert
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public void CommaSeperatedCookieNamesTest_Multiple_Cookie_Values_Json_Formatting()
+        {
+            var expectedResult = "[{\"key\":\"TEST\"},{\"Key1\":\"TEST1\"}]";
+
+            var cookie = new HttpCookie("key", "TEST") { ["Key1"] = "TEST1" };
+
+            var layoutRender = new AspNetRequestCookieLayoutRenderer()
+            {
+                CookieNames = new List<string> { "key", "key1" },
+                OutputFormat = AspNetRequestLayoutOutputFormat.JsonArray
+            };
+
+            var httpContextAccessorMock = CreateHttpContextAccessorMockWithCookie(cookie);
+            layoutRender.HttpContextAccessor = httpContextAccessorMock;
+
+            var result = layoutRender.Render(LogEventInfo.CreateNullEvent());
+
+            Assert.Equal(expectedResult, result);
+        }
+
+        private static IHttpContextAccessor CreateHttpContextAccessorMockWithCookie(HttpCookie cookie)
+        {
+            var httpCookieCollection = new HttpCookieCollection { cookie };
+            var httpContextAccessorMock = Substitute.For<IHttpContextAccessor>();
+            httpContextAccessorMock.HttpContext.Request.Cookies.Returns(httpCookieCollection);
+            return httpContextAccessorMock;
+        }
+
+#endif
+
+        /// <summary>
+        /// Create cookie renderer with mocked HTTP context
+        /// </summary>
+        /// <param name="addSecondCookie">Add second cookie</param>
+        /// <param name="addMultiValueCookieKey">Make cookie multi-value by adding a second value to it</param>
+        /// <returns>Created cookie layout renderer</returns>
+        /// <remarks>
+        /// The parameter <paramref name="addMultiValueCookieKey"/> allows creation of multi-valued cookies with the same key,
+        /// as provided in the HttpCookie API for backwards compatibility with classic ASP.
+        /// This is not supported in ASP.NET Core. For further details, see:
+        /// https://docs.microsoft.com/en-us/dotnet/api/system.web.httpcookie.item?view=netframework-4.7.1#System_Web_HttpCookie_Item_System_String_
+        /// https://stackoverflow.com/a/43831482/6651
+        /// https://github.com/aspnet/HttpAbstractions/issues/831
+        /// </remarks>
+        private AspNetResponseCookieLayoutRenderer CreateRenderer(bool addSecondCookie = true, bool addMultiValueCookieKey = false)
+        {
+            var cookieNames = new List<string>();
+#if ASP_NET_CORE
+            var httpContext = HttpContext;
+#else
+            var httpContext = Substitute.For<HttpContextBase>();
+#endif
+
+#if ASP_NET_CORE
+            void AddCookie(string key, string value)
+            {
+                cookieNames.Add(key);
+
+                httpContext.Response.Cookies.Append(key,value);
+            }
+
+            AddCookie("key", "TEST");
+
+            if (addSecondCookie)
+            {
+                AddCookie("Key1", "TEST1");
+            }
+
+            if (addMultiValueCookieKey)
+            {
+                throw new NotSupportedException("Multi-valued cookie keys are not supported in ASP.NET Core");
+            }
+
+#else
+
+            var cookie1 = new HttpCookie("key", "TEST");
+            var cookies = new HttpCookieCollection { cookie1 };
+            cookieNames.Add("key");
+
+            if (addSecondCookie)
+            {
+                var cookie2 = new HttpCookie("Key1", "TEST1");
+                cookies.Add(cookie2);
+                cookieNames.Add("Key1");
+            }
+
+            if (addMultiValueCookieKey)
+            {
+                var multiValueCookie = new HttpCookie("key2", "Test");
+                multiValueCookie["key3"] = "Test456";
+                cookies.Add(multiValueCookie);
+                cookieNames.Add("key2");
+            }
+
+            httpContext.Response.Cookies.Returns(cookies);
+#endif
+
+            var renderer = new AspNetResponseCookieLayoutRenderer();
+            renderer.HttpContextAccessor = new FakeHttpContextAccessor(httpContext);
+            renderer.CookieNames = cookieNames;
+            return renderer;
+        }
+    }
+}


### PR DESCRIPTION
Add Response Cookie Layout Render based on request Cookie layout render.
But, this has important difference for ASP.NET Core version.
We need to install Microsoft.AspNetCore.Http.Extensions NuGet package version 2.1.x other wise the cookie for response can only be Append() or Delete().
So, when we install this NuGet, it installs extension methods for Session named GetString() and GetInt32().
So these 2 method need to be delete from HttpContextExtensions.cs otherwise compiler gives 2 ambiguous call errors.
After these are deleted, re-executing all the unit test still give successful results.
