### PR TITLE
AspNetRequestCookieLayoutRenderer + AspNetResponseCookieLayoutRenderer with better code-reuse

### DIFF
--- a/src/NLog.Web/Internal/HttpCookieCollectionValues.cs
+++ b/src/NLog.Web/Internal/HttpCookieCollectionValues.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Web;
+
+namespace NLog.Web.Internal
+{
+    internal static class HttpCookieCollectionValues
+    {
+        internal static IEnumerable<KeyValuePair<string, string>> GetCookieValues(HttpCookieCollection cookies, List<string> cookieNames, HashSet<string> excludeNames, bool expandMultiValue)
+        {
+            if (cookieNames?.Count > 0)
+            {
+                return GetCookieNameValues(cookies, cookieNames, expandMultiValue);
+            }
+            else
+            {
+                return GetCookieAllValues(cookies, excludeNames, expandMultiValue);
+            }
+        }
+
+        private static IEnumerable<KeyValuePair<string, string>> GetCookieNameValues(HttpCookieCollection cookies, List<string> cookieNames, bool expandMultiValue)
+        {
+            foreach (var cookieName in cookieNames)
+            {
+                var httpCookie = cookies[cookieName];
+                if (httpCookie != null)
+                {
+                    if (expandMultiValue)
+                    {
+                        var values = httpCookie.Values;
+                        if (values?.Count > 1)
+                        {
+                            foreach (var cookieValue in GetCookieMultiValues(httpCookie.Name, values))
+                                yield return new KeyValuePair<string, string>(cookieValue.Key, cookieValue.Value);
+                            continue;
+                        }
+                    }
+
+                    yield return new KeyValuePair<string, string>(httpCookie.Name, httpCookie.Value);
+                }
+            }
+        }
+
+        private static IEnumerable<KeyValuePair<string, string>> GetCookieAllValues(HttpCookieCollection cookies, HashSet<string> excludeNames, bool expandMultiValue)
+        {
+            bool checkForExclude = excludeNames?.Count > 0;
+
+            foreach (string cookieName in cookies.Keys)
+            {
+                if (checkForExclude && excludeNames.Contains(cookieName))
+                    continue;
+
+                var httpCookie = cookies[cookieName];
+                if (httpCookie != null)
+                {
+                    if (expandMultiValue)
+                    {
+                        var values = httpCookie.Values;
+                        if (values?.Count > 1)
+                        {
+                            foreach (var cookieValue in GetCookieMultiValues(httpCookie.Name, values))
+                                yield return new KeyValuePair<string, string>(cookieValue.Key, cookieValue.Value);
+                            continue;
+                        }
+                    }
+
+                    yield return new KeyValuePair<string, string>(httpCookie.Name, httpCookie.Value);
+                }
+            }
+        }
+
+        private static IEnumerable<KeyValuePair<string, string>> GetCookieMultiValues(string firstKey, NameValueCollection httpCookiValues)
+        {
+            // Split multi-valued cookie, as allowed for in the HttpCookie API for backwards compatibility with classic ASP
+            var isFirst = true;
+            foreach (var multiValueKey in httpCookiValues.AllKeys)
+            {
+                var cookieKey = multiValueKey;
+                if (isFirst)
+                {
+                    cookieKey = firstKey;
+                    isFirst = false;
+                }
+                yield return new KeyValuePair<string, string>(cookieKey, httpCookiValues[multiValueKey]);
+            }
+        }
+    }
+}

--- a/src/Shared/LayoutRenderers/AspNetRequestCookieLayoutRenderer.cs
+++ b/src/Shared/LayoutRenderers/AspNetRequestCookieLayoutRenderer.cs
@@ -2,17 +2,13 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using NLog.Config;
 using NLog.LayoutRenderers;
 using NLog.Web.Internal;
 #if !ASP_NET_CORE
 using NLog.Web.Enums;
-using System.Collections.Specialized;
 using System.Web;
-using Cookies = System.Web.HttpCookieCollection;
 #else
 using Microsoft.AspNetCore.Http;
-using Cookies = Microsoft.AspNetCore.Http.IRequestCookieCollection;
 #endif
 
 namespace NLog.Web.LayoutRenderers
@@ -73,68 +69,40 @@ namespace NLog.Web.LayoutRenderers
             var cookies = httpRequest.Cookies;
             if (cookies?.Count > 0)
             {
-                bool checkForExclude = (CookieNames == null || CookieNames.Count == 0) && Exclude?.Count > 0;
-                var cookieValues = GetCookieValues(cookies, checkForExclude);
+                var cookieValues = GetCookieValues(cookies);
                 SerializePairs(cookieValues, builder, logEvent);
             }
         }
 
 #if !ASP_NET_CORE
-        private IEnumerable<KeyValuePair<string, string>> GetCookieValues(HttpCookieCollection cookies, bool checkForExclude)
+        private IEnumerable<KeyValuePair<string, string>> GetCookieValues(HttpCookieCollection cookies)
         {
-            var cookieNames = GetCookieNames(cookies);
-            foreach (var cookieName in cookieNames)
-            {
-                if (checkForExclude && Exclude.Contains(cookieName))
-                    continue;
-
-                var httpCookie = cookies[cookieName];
-                if (httpCookie == null)
-                {
-                    continue;
-                }
-
-                if (OutputFormat != AspNetRequestLayoutOutputFormat.Flat)
-                {
-                    // Split multi-valued cookie, as allowed for in the HttpCookie API for backwards compatibility with classic ASP
-                    var isFirst = true;
-                    foreach (var multiValueKey in httpCookie.Values.AllKeys)
-                    {
-                        var cookieKey = multiValueKey;
-                        if (isFirst)
-                        {
-                            cookieKey = cookieName;
-                            isFirst = false;
-                        }
-                        yield return new KeyValuePair<string, string>(cookieKey, httpCookie.Values[multiValueKey]);
-                    }
-                }
-                else
-                {
-                    yield return new KeyValuePair<string, string>(cookieName, httpCookie.Value);
-                }
-            }
-        }
-
-        private List<string> GetCookieNames(HttpCookieCollection cookies)
-        {
-            return CookieNames?.Count > 0 ? CookieNames : cookies.Keys.Cast<string>().ToList();
+            var expandMultiValue = OutputFormat != AspNetRequestLayoutOutputFormat.Flat;
+            return HttpCookieCollectionValues.GetCookieValues(cookies, CookieNames, Exclude, expandMultiValue);
         }
 #else
-        private IEnumerable<KeyValuePair<string, string>> GetCookieValues(IRequestCookieCollection cookies, bool checkForExclude)
+        private IEnumerable<KeyValuePair<string, string>> GetCookieValues(IRequestCookieCollection cookies)
         {
-            var cookieNames = CookieNames?.Count > 0 ? CookieNames : cookies.Keys;
-            foreach (var cookieName in cookieNames)
+            if (CookieNames?.Count > 0)
             {
-                if (checkForExclude && Exclude.Contains(cookieName))
-                    continue;
-
-                if (!cookies.TryGetValue(cookieName, out var cookieValue))
+                foreach (var cookieName in CookieNames)
                 {
-                    continue;
+                    if (cookies.TryGetValue(cookieName, out var cookieValue))
+                    {
+                        yield return new KeyValuePair<string, string>(cookieName, cookieValue);
+                    }
                 }
+            }
+            else
+            {
+                bool checkForExclude = Exclude?.Count > 0;
+                foreach (var cookie in cookies)
+                {
+                    if (checkForExclude && Exclude.Contains(cookie.Key))
+                        continue;
 
-                yield return new KeyValuePair<string, string>(cookieName, cookieValue);
+                    yield return new KeyValuePair<string, string>(cookie.Key, cookie.Value);
+                }
             }
         }
 #endif

--- a/tests/Shared/LayoutRenderers/AspNetRequestWebSocketRequestedProtocolsLayoutRendererTests.cs
+++ b/tests/Shared/LayoutRenderers/AspNetRequestWebSocketRequestedProtocolsLayoutRendererTests.cs
@@ -35,7 +35,7 @@ namespace NLog.Web.Tests.LayoutRenderers
         {
             // Arrange
             var (renderer, httpContext) = CreateWithHttpContext();
-            renderer.OutputFormat = AspNetRequestLayoutOutputFormat.Json;
+            renderer.OutputFormat = AspNetRequestLayoutOutputFormat.JsonArray;
             httpContext.WebSocketRequestedProtocols.Returns(
                 new List<string>()
                 {
@@ -100,7 +100,7 @@ namespace NLog.Web.Tests.LayoutRenderers
         {
             // Arrange
             var (renderer, httpContext) = CreateWithHttpContext();
-            renderer.OutputFormat = AspNetRequestLayoutOutputFormat.Json;
+            renderer.OutputFormat = AspNetRequestLayoutOutputFormat.JsonArray;
             httpContext.WebSockets.WebSocketRequestedProtocols.Returns(
                 new List<string>()
                 {


### PR DESCRIPTION
And removed `ToList()`-calls and reduced enumerator-allocations and removed sequential-scanning with `SingleOrDefault`