### PR TITLE
Reverted default value for ShutdownOnDispose to false

### DIFF
--- a/src/NLog.Web.AspNetCore/NLogAspNetCoreOptions.cs
+++ b/src/NLog.Web.AspNetCore/NLogAspNetCoreOptions.cs
@@ -20,13 +20,5 @@ namespace NLog.Web
         /// The default options
         /// </summary>
         public static NLogAspNetCoreOptions Default { get; } = new NLogAspNetCoreOptions();
-
-        /// <summary>
-        /// Initializes a new instance of <see cref="NLogAspNetCoreOptions"/> with default values.
-        /// </summary>
-        public NLogAspNetCoreOptions()
-        {
-            ShutdownOnDispose = true;
-        }
     }
 }


### PR DESCRIPTION
Discovered that the Microsoft Host disposes the LoggerFactory on startup-exception, so any logging after that point will be lost. See also https://github.com/dotnet/runtime/issues/72225 

Instead it is better to explicit call NLog.LogManager.Shutdown(), so the NLog Logger is still works when logging the exception.

Reverting #691