### PR TITLE
AspNetSessionValueLayoutRenderer - Skip ReEntrantScopeLock for classic NLog.Web

### DIFF
--- a/src/Shared/Internal/ReEntrantScopeLock.cs
+++ b/src/Shared/Internal/ReEntrantScopeLock.cs
@@ -1,79 +1,27 @@
-using System;
 #if !NET35
-using System.Threading;
-#endif
-#if ASP_NET_CORE
-using HttpContextBase = Microsoft.AspNetCore.Http.HttpContext;
-#else
-using System.Web;
-#endif
 
 namespace NLog.Web.Internal
 {
+    using System;
+    using System.Threading;
+
     /// <summary>
-    /// Manages if a LayoutRenderer can be called recursively.
-    /// Especially used by AspNetSessionValueLayoutRenderer
-    /// 
-    /// Since NET 35 does not support AsyncLocal or even ThreadLocal
-    /// a different technique must be used for that platform
+    /// Manages if a LayoutRenderer can be called recursively using AsyncLocal
+    /// Example used by <see cref="NLog.Web.LayoutRenderers.AspNetSessionValueLayoutRenderer"/>
     /// </summary>
     internal readonly struct ReEntrantScopeLock : IDisposable
     {
-        internal ReEntrantScopeLock(HttpContextBase context)
+        public ReEntrantScopeLock(bool acquireLock = true)
         {
-            _httpContext = context;
-            IsLockAcquired = TryGetLock(context);
+            IsLockAcquired = acquireLock && TryGetLock();
         }
 
-        private readonly HttpContextBase _httpContext;
-
-        // Need to track if we were successful in the lock
-        // If we were not, we should not unlock in the dispose code
         internal bool IsLockAcquired { get; }
 
-#if NET35
-        private static readonly object ReEntrantLock = new object();
-
-        private static bool TryGetLock(HttpContextBase context)
-        {
-            // If context is null leave
-            if (context == null)
-            {
-                return false;
-            }
-
-            // If already locked, return false
-            if (context.Items?.Contains(ReEntrantLock) == true)
-            {
-                return false;
-            }
-
-            // Get the lock
-            context.Items[ReEntrantLock] = bool.TrueString;
-
-            // Indicate the lock was successfully acquired
-            return true;
-        }
-
-        public void Dispose()
-        {
-            // Only unlock if we were the ones who locked it
-            if (IsLockAcquired)
-            {
-                _httpContext.Items?.Remove(ReEntrantLock);
-            }
-        }
-#else
         private static readonly AsyncLocal<bool> ReEntrantLock = new AsyncLocal<bool>();
 
-        private static bool TryGetLock(HttpContextBase context)
+        private static bool TryGetLock()
         {
-            // If context is null leave
-            if (context == null)
-            {
-                return false;
-            }
-
             // If already locked, return false
             if (ReEntrantLock.Value)
             {
@@ -95,6 +43,8 @@ namespace NLog.Web.Internal
                 ReEntrantLock.Value = false;
             }
         }
-#endif
     }
 }
+
+
+#endif


### PR DESCRIPTION
Followup to #850 (Moved session-lookup so it is protected by the ReEntrant-Scope-Lock )