### PR TITLE
Skip allocating RouteData when only need to lookup single value

### DIFF
--- a/src/Shared/LayoutRenderers/AspNetMvcActionRenderer.cs
+++ b/src/Shared/LayoutRenderers/AspNetMvcActionRenderer.cs
@@ -29,11 +29,12 @@ namespace NLog.Web.LayoutRenderers
             var context = HttpContextAccessor.HttpContext;
 
 #if !ASP_NET_CORE
-            var controller = RouteTable.Routes?.GetRouteData(context)?.Values[key]?.ToString();
+            object actionValue = null;
+            RouteTable.Routes?.GetRouteData(context)?.Values?.TryGetValue(key, out actionValue);
 #else
-            var controller = context?.GetRouteData()?.Values?[key]?.ToString();
+            var actionValue = context?.GetRouteValue(key);
 #endif
-            builder.Append(controller);
+            builder.Append(actionValue?.ToString());
         }
     }
 }

--- a/src/Shared/LayoutRenderers/AspNetMvcControllerRenderer.cs
+++ b/src/Shared/LayoutRenderers/AspNetMvcControllerRenderer.cs
@@ -28,12 +28,14 @@ namespace NLog.Web.LayoutRenderers
 
             var context = HttpContextAccessor.HttpContext;
 
+
 #if !ASP_NET_CORE
-            var controller = RouteTable.Routes?.GetRouteData(context)?.Values[key]?.ToString();
+            object controllerValue = null;
+            RouteTable.Routes?.GetRouteData(context)?.Values?.TryGetValue(key, out controllerValue);
 #else
-            var controller = context?.GetRouteData()?.Values?[key]?.ToString();
+            var controllerValue = context?.GetRouteValue(key);
 #endif
-            builder.Append(controller);
+            builder.Append(controllerValue?.ToString());
         }
     }
 }

--- a/src/Shared/LayoutRenderers/AspNetRequestRouteParametersRenderer.cs
+++ b/src/Shared/LayoutRenderers/AspNetRequestRouteParametersRenderer.cs
@@ -1,12 +1,11 @@
 using System.Text;
-using NLog.LayoutRenderers;
 using System.Collections.Generic;
-using System.Linq;
 #if !ASP_NET_CORE
 using System.Web.Routing;
 #else
 using Microsoft.AspNetCore.Routing;
 #endif
+using NLog.LayoutRenderers;
 
 namespace NLog.Web.LayoutRenderers
 {
@@ -28,7 +27,13 @@ namespace NLog.Web.LayoutRenderers
         /// List Route Parameter' Key to be rendered from Request.
         /// If empty, then render all parameters
         /// </summary>
-        public List<string> RouteParameterKeys { get; set; }
+        public List<string> RouteParameterKeys { get => Items; set => Items = value; }
+
+        /// <summary>
+        /// List Route Parameter' Key to be rendered from Request.
+        /// If empty, then render all parameters
+        /// </summary>
+        public List<string> Items { get; set; }
 
         /// <inheritdoc/>
         protected override void DoAppend(StringBuilder builder, LogEventInfo logEvent)
@@ -39,41 +44,63 @@ namespace NLog.Web.LayoutRenderers
                 return;
             }
 
+            var routeParameterKeys = Items;
+
+            if (routeParameterKeys?.Count == 1 && !string.IsNullOrEmpty(routeParameterKeys[0]))
+            {
 #if !ASP_NET_CORE
-            RouteValueDictionary routeParameters = RouteTable.Routes?.GetRouteData(context)?.Values;
+                object routeValue = null;
+                RouteTable.Routes?.GetRouteData(context)?.Values?.TryGetValue(routeParameterKeys[0], out routeValue);
 #else
-            RouteValueDictionary routeParameters = context.GetRouteData()?.Values;
+                var routeValue = context?.GetRouteValue(routeParameterKeys[0]);
 #endif
-            if (routeParameters == null || routeParameters.Count == 0)
-            {
-                return;
-            }
+                var routeStringValue = routeValue?.ToString();
+                if (!string.IsNullOrEmpty(routeStringValue))
+                {
 
-            var routeParameterKeys = RouteParameterKeys;
-            bool printAllRouteParameter = routeParameterKeys == null || routeParameterKeys.Count == 0;
-            if (printAllRouteParameter)
-            {
-                routeParameterKeys = routeParameters.Keys.ToList();
+                    var pair = new[] { new KeyValuePair<string, string>(routeParameterKeys[0], routeStringValue) };
+                    SerializePairs(pair, builder, logEvent);
+                }
             }
-
-            IEnumerable<KeyValuePair<string, string>> pairs = GetPairs(routeParameters, routeParameterKeys);
-            SerializePairs(pairs, builder, logEvent);
+            else
+            {
+#if !ASP_NET_CORE
+                RouteValueDictionary routeParameters = RouteTable.Routes?.GetRouteData(context)?.Values;
+#else
+                RouteValueDictionary routeParameters = context.GetRouteData()?.Values;
+#endif
+                if (routeParameters?.Count > 0)
+                {
+                    var pairs = GetPairs(routeParameters, routeParameterKeys);
+                    SerializePairs(pairs, builder, logEvent);
+                }
+            }
         }
 
         private static IEnumerable<KeyValuePair<string, string>> GetPairs(RouteValueDictionary routeParameters, List<string> routeParameterKeys)
         {
-            foreach (string key in routeParameterKeys)
+            if (routeParameterKeys?.Count > 0)
             {
-                // This platform specific code is to prevent an unncessary .ToString call otherwise. 
-                if (!routeParameters.TryGetValue(key, out object objValue))
+                foreach (var routeKey in routeParameterKeys)
                 {
-                    continue;
+                    if (routeParameters.TryGetValue(routeKey, out var routeValue))
+                    {
+                        string value = routeValue?.ToString();
+                        if (!string.IsNullOrEmpty(value))
+                            yield return new KeyValuePair<string, string>(routeKey, value);
+                    }
                 }
-
-                string value = objValue?.ToString();
-                if (!string.IsNullOrEmpty(value))
+            }
+            else
+            {
+                // Output all route-values
+                foreach (var routeItem in routeParameters)
                 {
-                    yield return new KeyValuePair<string, string>(key, value);
+                    string routeValue = routeItem.Value?.ToString();
+                    if (!string.IsNullOrEmpty(routeValue))
+                    {
+                        yield return new KeyValuePair<string, string>(routeItem.Key, routeValue);
+                    }
                 }
             }
         }

--- a/tests/NLog.Web.AspNetCore.Tests/LayoutRenderers/AspNetRequestTlsHandshakeLayoutRendererTests.cs
+++ b/tests/NLog.Web.AspNetCore.Tests/LayoutRenderers/AspNetRequestTlsHandshakeLayoutRendererTests.cs
@@ -125,19 +125,6 @@ namespace NLog.Web.Tests.LayoutRenderers
             // Assert
             Assert.Equal(SslProtocols.Tls13.ToString(), result);
         }
-
-
-        protected override void NullRendersEmptyString()
-        {
-            // Arrange
-            var (renderer, _) = CreateWithHttpContext();
-
-            // Act
-            string result = renderer.Render(LogEventInfo.CreateNullEvent());
-
-            // Assert
-            Assert.Equal("None", result);
-        }
     }
 }
 #endif

--- a/tests/NLog.Web.AspNetCore.Tests/LayoutRenderers/AspNetRequestTrackingConsentLayoutRendererTests.cs
+++ b/tests/NLog.Web.AspNetCore.Tests/LayoutRenderers/AspNetRequestTrackingConsentLayoutRendererTests.cs
@@ -108,7 +108,7 @@ namespace NLog.Web.Tests.LayoutRenderers
             string result = renderer.Render(LogEventInfo.CreateNullEvent());
 
             // Assert
-            Assert.Equal("0", result);
+            Assert.Equal("1", result);
         }
     }
 }

--- a/tests/Shared/LayoutRenderers/AspNetRequestRouteParametersRendererTests.cs
+++ b/tests/Shared/LayoutRenderers/AspNetRequestRouteParametersRendererTests.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using NLog.Web.LayoutRenderers;
-using NLog.Web.Enums;
 using Xunit;
-using System.Collections.Specialized;
 using NSubstitute;
 #if ASP_NET_CORE
 using Microsoft.AspNetCore.Http;
@@ -15,21 +13,6 @@ namespace NLog.Web.Tests.LayoutRenderers
 {
     public class AspNetRequestRouteParametersRendererTests : LayoutRenderersTestBase<AspNetRequestRouteParametersRenderer>
     {
-        [Fact]
-        public void NullRouteParametersRenderersEmptyString()
-        {
-            // Arrange
-            var (renderer, httpContext) = CreateWithHttpContext();
-
-            AddRoutingFeature(httpContext);
-
-            // Act
-            string result = renderer.Render(LogEventInfo.CreateNullEvent());
-
-            // Assert
-            Assert.Empty(result);
-        }
-
 #if ASP_NET_CORE
         [Fact]
         public void NullKeyRendersAllRouteParameters()
@@ -69,6 +52,11 @@ namespace NLog.Web.Tests.LayoutRenderers
             var routingFeature = Substitute.For<IRoutingFeature>();
             var collection = new FeatureCollection();
             collection.Set(routingFeature);
+#if ASP_NET_CORE3
+            var routingValuesFeature = Substitute.For<IRouteValuesFeature>();
+            routingValuesFeature.RouteValues.Returns(routeData.Values);
+            collection.Set(routingValuesFeature);
+#endif
             httpContext.Features.Returns(collection);
 
             routeData.Values.Add("key1", "value1");

--- a/tests/Shared/LayoutRenderers/AspNetSessionIDLayoutRendererTests.cs
+++ b/tests/Shared/LayoutRenderers/AspNetSessionIDLayoutRendererTests.cs
@@ -3,8 +3,6 @@ using System.Web;
 using System.Web.Routing;
 using System.Collections.Specialized;
 using System.Web.SessionState;
-#else
-using HttpContextBase = Microsoft.AspNetCore.Http.HttpContext;
 #endif
 using NLog.Web.LayoutRenderers;
 using NSubstitute;

--- a/tests/Shared/LayoutRenderers/AspNetSessionValueLayoutRendererTests2.cs
+++ b/tests/Shared/LayoutRenderers/AspNetSessionValueLayoutRendererTests2.cs
@@ -92,8 +92,7 @@ namespace NLog.Web.Tests.LayoutRenderers
             mockSession.SetInt32("b", 123);
             httpContext.Session = mockSession;
             httpContext.Items = new Dictionary<object, object>();
-            var sessionFeature = new SessionFeatureMock(mockSession);
-            httpContext.Features.Get<ISessionFeature>().Returns(sessionFeature);
+
             return (renderer, httpContext);
         }
 

--- a/tests/Shared/LayoutRenderers/LayoutRenderersTestBase.cs
+++ b/tests/Shared/LayoutRenderers/LayoutRenderersTestBase.cs
@@ -3,6 +3,7 @@ using NLog.Web.Tests;
 using NSubstitute;
 using Xunit;
 #if ASP_NET_CORE
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Routing;
 using HttpContextBase = Microsoft.AspNetCore.Http.HttpContext;
@@ -33,10 +34,19 @@ namespace NLog.Web.Tests.LayoutRenderers
             Assert.Empty(result);
         }
 
-        protected static (TLayoutRenderer renderer, HttpContextBase httpContext) CreateWithHttpContext()
-           
+        protected static (TLayoutRenderer renderer, HttpContextBase httpContext) CreateWithHttpContext()          
         {
             var httpContext = Substitute.For<HttpContextBase>();
+#if ASP_NET_CORE
+            var collection = new FeatureCollection();
+            var routingFeature = Substitute.For<IRoutingFeature>();
+            routingFeature.RouteData.Returns(new RouteData());
+            collection.Set<IRoutingFeature>(routingFeature);
+            var sessionFeature = Substitute.For<ISessionFeature>();
+            sessionFeature.Session.Returns(Substitute.For<ISession>());
+            collection.Set<ISessionFeature>(sessionFeature);
+            httpContext.Features.Returns(collection);
+#endif
 #if ASP_NET_CORE3
             httpContext.Request.RouteValues.Returns(new RouteValueDictionary());
 #endif
@@ -45,16 +55,6 @@ namespace NLog.Web.Tests.LayoutRenderers
                 HttpContextAccessor = new FakeHttpContextAccessor(httpContext)
             };
             return (renderer, httpContext);
-        }
-
-        protected static void AddRoutingFeature(HttpContextBase httpContext)
-        {
-#if ASP_NET_CORE
-            var routingFeature = Substitute.For<IRoutingFeature>();
-            var collection = new FeatureCollection();
-            collection.Set<IRoutingFeature>(routingFeature);
-            httpContext.Features.Returns(collection);
-#endif
         }
     }
 }


### PR DESCRIPTION
Optimizing:
- AspNetMvcActionRenderer - `${aspnet-mvc-action}`
- AspNetMvcControllerRenderer - `${aspnet-mvc-controller}`
- AspNetRequestRouteParametersRenderer - `${aspnet-request-routeparameters}`