### PR TITLE
AspNetLayoutRendererBase - Skip allocating extra HttpContextWrapper

### DIFF
--- a/src/NLog.Web/DefaultHttpContextAccessor.cs
+++ b/src/NLog.Web/DefaultHttpContextAccessor.cs
@@ -21,5 +21,9 @@ namespace NLog.Web
             }
         }
 
+        internal bool HasActiveHttpContext()
+        {
+            return System.Web.HttpContext.Current != null;  // Skip allocating HttpContextWrapper
+        }
     }
 }

--- a/src/Shared/Internal/HttpContextExtensions.cs
+++ b/src/Shared/Internal/HttpContextExtensions.cs
@@ -17,6 +17,14 @@ namespace NLog.Web.Internal
     internal static class HttpContextExtensions
     {
 #if !ASP_NET_CORE
+        internal static bool HasActiveHttpContext(this IHttpContextAccessor httpContextAccessor)
+        {
+            if (httpContextAccessor is DefaultHttpContextAccessor defaultHttpContextAccessor)
+                return defaultHttpContextAccessor.HasActiveHttpContext();    // Skip allocating HttpContextWrapper
+            else
+                return httpContextAccessor?.HttpContext != null;
+        }
+
         internal static HttpRequestBase TryGetRequest(this HttpContextBase context)
         {
             try
@@ -49,6 +57,11 @@ namespace NLog.Web.Internal
             }
         }
 #else
+        internal static bool HasActiveHttpContext(this IHttpContextAccessor httpContextAccessor)
+        {
+            return httpContextAccessor?.HttpContext != null;
+        }
+
         internal static WebSocketManager TryGetWebSocket(this HttpContext context)
         {
             var websocket = context?.WebSockets;

--- a/src/Shared/LayoutRenderers/AspNetLayoutRendererBase.cs
+++ b/src/Shared/LayoutRenderers/AspNetLayoutRendererBase.cs
@@ -1,10 +1,10 @@
 ﻿using System;
-using System.Linq;
 using System.Text;
 
 using NLog.Common;
 using NLog.Config;
 using NLog.LayoutRenderers;
+using NLog.Web.Internal;
 #if ASP_NET_CORE
 using Microsoft.AspNetCore.Http;
 using HttpContextBase = Microsoft.AspNetCore.Http.HttpContext;
@@ -40,7 +40,6 @@ namespace NLog.Web.LayoutRenderers
         internal static IHttpContextAccessor DefaultHttpContextAccessor { get; set; } = new DefaultHttpContextAccessor();
         internal static IHttpContextAccessor RetrieveHttpContextAccessor(IServiceProvider serviceProvider, LoggingConfiguration loggingConfiguration) => DefaultHttpContextAccessor;
 #else
-
         internal static IHttpContextAccessor RetrieveHttpContextAccessor(IServiceProvider serviceProvider, LoggingConfiguration loggingConfiguration)
         {
             return ServiceLocator.ResolveService<IHttpContextAccessor>(serviceProvider, loggingConfiguration);
@@ -54,13 +53,7 @@ namespace NLog.Web.LayoutRenderers
         /// <param name="logEvent">Logging event.</param>
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
-            var httpContextAccessor = HttpContextAccessor;
-            if (httpContextAccessor == null)
-            {
-                return;
-            }
-
-            if (httpContextAccessor.HttpContext == null)
+            if (!HttpContextAccessor.HasActiveHttpContext())
             {
                 InternalLogger.Debug("No available HttpContext, because outside valid request context. Logger: {0}", logEvent.LoggerName);
                 return;


### PR DESCRIPTION
Reducing the overhead of AspNetLayoutRendererBase before making it obsolete with #846