### PR TITLE
AspNetBufferingTargetWrapper - Use NLogHttpModule EventHandler like before

### DIFF
--- a/src/NLog.Web/NLogHttpModule.cs
+++ b/src/NLog.Web/NLogHttpModule.cs
@@ -1,6 +1,4 @@
-﻿using NLog.Web.Targets.Wrappers;
-using System;
-using System.Runtime.InteropServices;
+﻿using System;
 using System.Web;
 
 namespace NLog.Web
@@ -42,24 +40,11 @@ namespace NLog.Web
         private void BeginRequestHandler(object sender, EventArgs args)
         {
             BeginRequest?.Invoke(sender, args);
-            OnBeginRequest((sender as HttpApplication)?.Context);
-
         }
 
         private void EndRequestHandler(object sender, EventArgs args)
         {
             EndRequest?.Invoke(sender, args);
-            OnEndRequest((sender as HttpApplication)?.Context);
-        }
-
-        internal void OnBeginRequest(HttpContext context)
-        {
-            AspNetBufferingTargetWrapper.OnBeginRequest(context);
-        }
-
-        internal void OnEndRequest(HttpContext context)
-        {
-            AspNetBufferingTargetWrapper.OnEndRequest(context);
         }
     }
 }

--- a/tests/Shared/Targets/AspNetBufferingTargetWrapperTests.cs
+++ b/tests/Shared/Targets/AspNetBufferingTargetWrapperTests.cs
@@ -127,6 +127,11 @@ namespace NLog.Web.Tests
 
             Assert.Equal("9", debugTarget.LastMessage);
 
+            // Verify that logging after end-request are not buffered
+            logFactory.GetCurrentClassLogger().Debug(666);
+            Assert.Equal(10, debugTarget.Counter);
+            Assert.Equal("666", debugTarget.LastMessage);
+
             logFactory.Shutdown();
         }
 
@@ -172,6 +177,11 @@ namespace NLog.Web.Tests
                 Assert.Equal(j.ToString(), message);
                 j++;
             }
+
+            // Verify that logging after end-request are not buffered
+            logFactory.GetCurrentClassLogger().Debug(666);
+            Assert.Equal(10, memoryTarget.Logs.Count);
+            Assert.Equal("666", memoryTarget.Logs.Last());
 
             logFactory.Shutdown();
         }
@@ -482,10 +492,9 @@ namespace NLog.Web.Tests
 #else
         private void ExecuteLogging(System.Web.HttpContext httpContext, Action loggingInvoker)
         {
-            var httpModule = new NLogHttpModule();
-            httpModule.OnBeginRequest(httpContext);
+            AspNetBufferingTargetWrapper.OnBeginRequest(httpContext);
             loggingInvoker();
-            httpModule.OnEndRequest(httpContext);
+            AspNetBufferingTargetWrapper.OnEndRequest(httpContext);
         }
 #endif
 


### PR DESCRIPTION
Follow up to #900 (Avoid breaking changes)