### PR TITLE
Enable http status code layout renderer to output both the int and En…

### DIFF
--- a/src/Shared/LayoutRenderers/AspNetResponseStatusCodeRenderer.cs
+++ b/src/Shared/LayoutRenderers/AspNetResponseStatusCodeRenderer.cs
@@ -1,4 +1,6 @@
-﻿using System.Text;
+﻿using System;
+using System.Net;
+using System.Text;
 using NLog.Config;
 using NLog.LayoutRenderers;
 using NLog.Web.Internal;
@@ -9,12 +11,24 @@ namespace NLog.Web.LayoutRenderers
     /// ASP.NET Response Status Code.
     /// </summary>
     /// <remarks>
-    /// <code>${aspnet-response-statuscode}</code>
+    /// <code>${aspnet-response-statuscode} emits the http status code as an int</code>
+    /// <code>${aspnet-response-statuscode:Format=d} also emits the http status code as an int</code>
+    /// <code>${aspnet-response-statuscode:Format=[anything other than d]} emits the http status code as the enum HttpStatusCode.ToString()</code>
     /// </remarks>
     /// <seealso href="https://github.com/NLog/NLog/wiki/AspNetResponse-StatusCode-Layout-Renderer">Documentation on NLog Wiki</seealso>
     [LayoutRenderer("aspnet-response-statuscode")]
     public class AspNetResponseStatusCodeRenderer : AspNetLayoutRendererBase
     {
+        private const string IntegerFormat = "d";
+
+        /// <summary>
+        /// If this is 'd', output the int of the http status code
+        /// Otherwise, output the Enum.ToString() of the HttpStatusCode.
+        /// Defaults to 'd'
+        /// </summary>
+        [DefaultParameter]
+        public string Format { get; set; } = IntegerFormat;
+
         /// <inheritdoc/>
         protected override void DoAppend(StringBuilder builder, LogEventInfo logEvent)
         {
@@ -24,11 +38,22 @@ namespace NLog.Web.LayoutRenderers
                 return;
             }
 
-            int statusCode = httpResponse.StatusCode;
+            var statusCode = httpResponse.StatusCode;
+            if (statusCode < 100 || statusCode > 599)
+            {
+                // Only output valid HTTP status codes
+                return;
+            }
 
-            if (statusCode >= 100 && statusCode <= 599)
+            // .NET format strings are case-insensitive
+            // See https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings
+            if (string.Equals(Format, IntegerFormat, StringComparison.InvariantCultureIgnoreCase))
             {
                 builder.Append(statusCode);
+            }
+            else
+            {
+                builder.Append(((HttpStatusCode)statusCode).ToString());
             }
         }
     }

--- a/src/Shared/LayoutRenderers/AspNetResponseStatusCodeRenderer.cs
+++ b/src/Shared/LayoutRenderers/AspNetResponseStatusCodeRenderer.cs
@@ -11,22 +11,28 @@ namespace NLog.Web.LayoutRenderers
     /// ASP.NET Response Status Code.
     /// </summary>
     /// <remarks>
-    /// <code>${aspnet-response-statuscode} emits the http status code as an int</code>
-    /// <code>${aspnet-response-statuscode:Format=value} where value is a valid enumeration format string emits the specified format</code>
-    /// 'value' is case-insensitive
-    /// Supported formats for 'value'
-    /// f or g: outputs the HttpStatusCode enum as a string if possible, otherwise an int
-    /// d: outputs the HttpStatusCode enum as a int
-    /// x: outputs the HttpStatusCode enum as a hexdecimal
-    /// See https://learn.microsoft.com/en-us/dotnet/standard/base-types/enumeration-format-strings for more information
+    /// <code>${aspnet-response-statuscode}          emits the http status code as integer</code>
+    /// <code>${aspnet-response-statuscode:Format=D} emits the http status code as integer</code>
+    /// <code>${aspnet-response-statuscode:Format=F} emits the http status code as enum-string-value</code>
+    /// <code>${aspnet-response-statuscode:Format=G} emits the http status code as enum-string-value</code>
+    /// <code>${aspnet-response-statuscode:Format=X} emits the http status code as hexadecimal</code>
     /// </remarks>
     /// <seealso href="https://github.com/NLog/NLog/wiki/AspNetResponse-StatusCode-Layout-Renderer">Documentation on NLog Wiki</seealso>
     [LayoutRenderer("aspnet-response-statuscode")]
     public class AspNetResponseStatusCodeRenderer : AspNetLayoutRendererBase
     {
         /// <summary>
-        /// A valid enumeration format string
+        /// A valid enumeration format string, defaults to integer format
         /// </summary>
+        /// <remarks>
+        /// Supported Values, Case Insensitive
+        /// D: outputs the HttpStatusCode enum as a integer
+        /// F: outputs the HttpStatusCode enum as a string if possible, otherwise an integer
+        /// G: outputs the HttpStatusCode enum as a string if possible, otherwise an integer
+        /// X: outputs the HttpStatusCode enum as a hexadecimal
+        /// </remarks>
+        /// <seealso href="https://learn.microsoft.com/en-us/dotnet/standard/base-types/enumeration-format-strings">Documentation on Enum Format Strings</seealso>
+
         [DefaultParameter]
         public string Format { get; set; } = "d";
 

--- a/src/Shared/LayoutRenderers/AspNetResponseStatusCodeRenderer.cs
+++ b/src/Shared/LayoutRenderers/AspNetResponseStatusCodeRenderer.cs
@@ -24,13 +24,11 @@ namespace NLog.Web.LayoutRenderers
     [LayoutRenderer("aspnet-response-statuscode")]
     public class AspNetResponseStatusCodeRenderer : AspNetLayoutRendererBase
     {
-        private const string IntegerFormat = "d";
-
         /// <summary>
         /// A valid enumeration format string
         /// </summary>
         [DefaultParameter]
-        public string Format { get; set; } = IntegerFormat;
+        public string Format { get; set; } = "d";
 
         /// <inheritdoc/>
         protected override void DoAppend(StringBuilder builder, LogEventInfo logEvent)

--- a/tests/Shared/LayoutRenderers/AspNetResponseStatusCodeRendererTests.cs
+++ b/tests/Shared/LayoutRenderers/AspNetResponseStatusCodeRendererTests.cs
@@ -22,11 +22,27 @@ namespace NLog.Web.Tests.LayoutRenderers
         }
 
         [Fact]
-        public void StatusCode_Set_Renderer_EnumFormat()
+        public void StatusCode_Set_Renderer_EnumFormatF()
         {
             // Arrange
             var (renderer, httpContext) = CreateWithHttpContext();
-            renderer.Format = "e";
+            renderer.Format = "f";
+
+            httpContext.Response.StatusCode.Returns(200);
+
+            // Act
+            string result = renderer.Render(new LogEventInfo());
+
+            // Assert
+            Assert.Equal(((HttpStatusCode)200).ToString(), result);
+        }
+
+        [Fact]
+        public void StatusCode_Set_Renderer_EnumFormatG()
+        {
+            // Arrange
+            var (renderer, httpContext) = CreateWithHttpContext();
+            renderer.Format = "g";
 
             httpContext.Response.StatusCode.Returns(200);
 
@@ -51,6 +67,38 @@ namespace NLog.Web.Tests.LayoutRenderers
 
             // Assert
             Assert.Equal("200", result);
+        }
+
+        [Fact]
+        public void StatusCode_Set_Renderer_HexFormat()
+        {
+            // Arrange
+            var (renderer, httpContext) = CreateWithHttpContext();
+            renderer.Format = "x";
+
+            httpContext.Response.StatusCode.Returns(200);
+
+            // Act
+            string result = renderer.Render(new LogEventInfo());
+
+            // Assert
+            Assert.Equal(((HttpStatusCode)200).ToString("x"), result);
+        }
+
+        [Fact]
+        public void StatusCode_Set_Renderer_InvalidFormat()
+        {
+            // Arrange
+            var (renderer, httpContext) = CreateWithHttpContext();
+            renderer.Format = "invalid";
+
+            httpContext.Response.StatusCode.Returns(200);
+
+            // Act
+            string result = renderer.Render(new LogEventInfo());
+
+            // Assert
+            Assert.Equal("", result);
         }
 
         [Fact]
@@ -101,11 +149,39 @@ namespace NLog.Web.Tests.LayoutRenderers
         [InlineData(100, true)]
         [InlineData(599, true)]
         [InlineData(600, false)]
-        public void Only_Render_Valid_StatusCodes_EnumFormat(int statusCode, bool shouldBeRendered)
+        public void Only_Render_Valid_StatusCodes_EnumFormatF(int statusCode, bool shouldBeRendered)
         {
             // Arrange
             var (renderer, httpContext) = CreateWithHttpContext();
-            renderer.Format = "e";
+            renderer.Format = "f";
+            httpContext.Response.StatusCode.Returns(statusCode);
+
+            // Act
+            string result = renderer.Render(new LogEventInfo());
+
+            // Assert
+            if (shouldBeRendered)
+            {
+                Assert.Equal(((HttpStatusCode)statusCode).ToString(), result);
+            }
+            else
+            {
+                Assert.Empty(result);
+            }
+        }
+
+
+        [Theory]
+        [InlineData(0, false)]
+        [InlineData(99, false)]
+        [InlineData(100, true)]
+        [InlineData(599, true)]
+        [InlineData(600, false)]
+        public void Only_Render_Valid_StatusCodes_EnumFormatG(int statusCode, bool shouldBeRendered)
+        {
+            // Arrange
+            var (renderer, httpContext) = CreateWithHttpContext();
+            renderer.Format = "g";
             httpContext.Response.StatusCode.Returns(statusCode);
 
             // Act
@@ -169,6 +245,33 @@ namespace NLog.Web.Tests.LayoutRenderers
             if (shouldBeRendered)
             {
                 Assert.Equal($"{statusCode}", result);
+            }
+            else
+            {
+                Assert.Empty(result);
+            }
+        }
+
+        [Theory]
+        [InlineData(0, false)]
+        [InlineData(99, false)]
+        [InlineData(100, true)]
+        [InlineData(599, true)]
+        [InlineData(600, false)]
+        public void Only_Render_Valid_StatusCodes_HexFormat(int statusCode, bool shouldBeRendered)
+        {
+            // Arrange
+            var (renderer, httpContext) = CreateWithHttpContext();
+            renderer.Format = "x";
+            httpContext.Response.StatusCode.Returns(statusCode);
+
+            // Act
+            string result = renderer.Render(new LogEventInfo());
+
+            // Assert
+            if (shouldBeRendered)
+            {
+                Assert.Equal(((HttpStatusCode)statusCode).ToString("x"), result);
             }
             else
             {

--- a/tests/Shared/LayoutRenderers/AspNetResponseStatusCodeRendererTests.cs
+++ b/tests/Shared/LayoutRenderers/AspNetResponseStatusCodeRendererTests.cs
@@ -1,4 +1,5 @@
-﻿using NLog.Web.LayoutRenderers;
+﻿using System.Net;
+using NLog.Web.LayoutRenderers;
 using NSubstitute;
 using Xunit;
 
@@ -7,10 +8,58 @@ namespace NLog.Web.Tests.LayoutRenderers
     public class AspNetResponseStatusCodeRendererTests : LayoutRenderersTestBase<AspNetResponseStatusCodeRenderer>
     {
         [Fact]
-        public void StatusCode_Set_Renderer()
+        public void StatusCode_Set_Renderer_DefaultFormat()
         {
             // Arrange
             var (renderer, httpContext) = CreateWithHttpContext();
+            httpContext.Response.StatusCode.Returns(200);
+
+            // Act
+            string result = renderer.Render(new LogEventInfo());
+
+            // Assert
+            Assert.Equal("200", result);
+        }
+
+        [Fact]
+        public void StatusCode_Set_Renderer_EnumFormat()
+        {
+            // Arrange
+            var (renderer, httpContext) = CreateWithHttpContext();
+            renderer.Format = "e";
+
+            httpContext.Response.StatusCode.Returns(200);
+
+            // Act
+            string result = renderer.Render(new LogEventInfo());
+
+            // Assert
+            Assert.Equal(((HttpStatusCode)200).ToString(), result);
+        }
+
+        [Fact]
+        public void StatusCode_Set_Renderer_IntegerFormat()
+        {
+            // Arrange
+            var (renderer, httpContext) = CreateWithHttpContext();
+            renderer.Format = "d";
+
+            httpContext.Response.StatusCode.Returns(200);
+
+            // Act
+            string result = renderer.Render(new LogEventInfo());
+
+            // Assert
+            Assert.Equal("200", result);
+        }
+
+        [Fact]
+        public void StatusCode_Set_Renderer_UpperCaseIntegerFormat()
+        {
+            // Arrange
+            var (renderer, httpContext) = CreateWithHttpContext();
+            renderer.Format = "D";
+
             httpContext.Response.StatusCode.Returns(200);
 
             // Act
@@ -26,10 +75,91 @@ namespace NLog.Web.Tests.LayoutRenderers
         [InlineData(100, true)]
         [InlineData(599, true)]
         [InlineData(600, false)]
-        public void Only_Render_Valid_StatusCodes(int statusCode, bool shouldBeRendered)
+        public void Only_Render_Valid_StatusCodes_DefaultFormat(int statusCode, bool shouldBeRendered)
         {
             // Arrange
             var (renderer, httpContext) = CreateWithHttpContext();
+            httpContext.Response.StatusCode.Returns(statusCode);
+
+            // Act
+            string result = renderer.Render(new LogEventInfo());
+
+            // Assert
+            if (shouldBeRendered)
+            {
+                Assert.Equal($"{statusCode}", result);
+            }
+            else
+            {
+                Assert.Empty(result);
+            }
+        }
+
+        [Theory]
+        [InlineData(0, false)]
+        [InlineData(99, false)]
+        [InlineData(100, true)]
+        [InlineData(599, true)]
+        [InlineData(600, false)]
+        public void Only_Render_Valid_StatusCodes_EnumFormat(int statusCode, bool shouldBeRendered)
+        {
+            // Arrange
+            var (renderer, httpContext) = CreateWithHttpContext();
+            renderer.Format = "e";
+            httpContext.Response.StatusCode.Returns(statusCode);
+
+            // Act
+            string result = renderer.Render(new LogEventInfo());
+
+            // Assert
+            if (shouldBeRendered)
+            {
+                Assert.Equal(((HttpStatusCode)statusCode).ToString(), result);
+            }
+            else
+            {
+                Assert.Empty(result);
+            }
+        }
+
+        [Theory]
+        [InlineData(0, false)]
+        [InlineData(99, false)]
+        [InlineData(100, true)]
+        [InlineData(599, true)]
+        [InlineData(600, false)]
+        public void Only_Render_Valid_StatusCodes_IntegerFormat(int statusCode, bool shouldBeRendered)
+        {
+            // Arrange
+            var (renderer, httpContext) = CreateWithHttpContext();
+            renderer.Format = "d";
+            httpContext.Response.StatusCode.Returns(statusCode);
+
+            // Act
+            string result = renderer.Render(new LogEventInfo());
+
+            // Assert
+            if (shouldBeRendered)
+            {
+                Assert.Equal($"{statusCode}", result);
+            }
+            else
+            {
+                Assert.Empty(result);
+            }
+        }
+
+        [Theory]
+        [InlineData(0, false)]
+        [InlineData(99, false)]
+        [InlineData(100, true)]
+        [InlineData(599, true)]
+        [InlineData(600, false)]
+        public void Only_Render_Valid_StatusCodes_UpperCaseIntegerFormat(int statusCode, bool shouldBeRendered)
+        {
+            // Arrange
+            var (renderer, httpContext) = CreateWithHttpContext();
+            renderer.Format = "D";
             httpContext.Response.StatusCode.Returns(statusCode);
 
             // Act


### PR DESCRIPTION
…um.ToString() versions of the status code, using a Format property that defaults to integer. Resolves #920