### PR TITLE
Handle malformed X-Forwarded-For Header

### DIFF
--- a/src/Shared/LayoutRenderers/AspNetRequestIpLayoutRenderer.cs
+++ b/src/Shared/LayoutRenderers/AspNetRequestIpLayoutRenderer.cs
@@ -17,9 +17,9 @@ namespace NLog.Web.LayoutRenderers
     /// <remarks>
     /// <code>${aspnet-request-ip}</code> to return the Remote IP
     /// <code>${aspnet-request-ip:CheckForwardedForHeader=true}</code> to return first element in the X-Forwarded-For header
-    /// <code>${aspnet-request-ip:CheckForwardedForHeader=true:Index=1}</code> to return second element in the X-Forwarded-For header
-    /// <code>${aspnet-request-ip:CheckForwardedForHeader=true:Index=-1}</code> to return last element in the X-Forwarded-For header
-    /// <code>${aspnet-request-ip:CheckForwardedForHeader=true:Index=1:ForwardedForHeader=myHeader}</code> to return second element in the myHeader header
+    /// <code>${aspnet-request-ip:CheckForwardedForHeaderOffset=1}</code>  to return second element in the X-Forwarded-For header
+    /// <code>${aspnet-request-ip:CheckForwardedForHeaderOffset=-1}</code> to return last element in the X-Forwarded-For header
+    /// <code>${aspnet-request-ip:CheckForwardedForHeaderOffset=1:ForwardedForHeader=myHeader}</code> to return second element in the myHeader header
     /// </remarks>
     /// <seealso href="https://github.com/NLog/NLog/wiki/AspNet-Request-IP-Layout-Renderer">Documentation on NLog Wiki</seealso>
     [LayoutRenderer("aspnet-request-ip")]
@@ -44,7 +44,16 @@ namespace NLog.Web.LayoutRenderers
         /// Minus one will indicate the last element in the array.  If the negative index is too large the first index
         /// of the array is returned instead.
         /// </summary>
-        public int Index { get; set; } = 0;
+        public int CheckForwardedForHeaderOffset
+        {
+            get => _checkForwardedForHeaderOffset;
+            set
+            {
+                _checkForwardedForHeaderOffset = value;
+                CheckForwardedForHeader = true;
+            }
+        }
+        private int _checkForwardedForHeaderOffset;
 
         /// <inheritdoc/>
         protected override void DoAppend(StringBuilder builder, LogEventInfo logEvent)
@@ -73,7 +82,7 @@ namespace NLog.Web.LayoutRenderers
 
         private int CalculatePosition(string[] headerContents)
         {
-            var position = Index;
+            var position = CheckForwardedForHeaderOffset;
 
             if (position < 0)
             {

--- a/src/Shared/LayoutRenderers/AspNetRequestIpLayoutRenderer.cs
+++ b/src/Shared/LayoutRenderers/AspNetRequestIpLayoutRenderer.cs
@@ -40,6 +40,9 @@ namespace NLog.Web.LayoutRenderers
         /// <summary>
         /// Gets or sets the array index of the X-Forwarded-For header to use, if the desired client IP is not at
         /// the zeroth index.  Defaults to zero.  If the index is too large the last array element is returned instead.
+        /// If a negative index is used, this is used as the position from the end of the array.
+        /// Minus one will indicate the last element in the array.  If the negative index is too large the first index
+        /// of the array is returned instead.
         /// </summary>
         public int Index { get; set; } = 0;
 

--- a/tests/Shared/LayoutRenderers/AspNetRequestIpLayoutRendererTests.cs
+++ b/tests/Shared/LayoutRenderers/AspNetRequestIpLayoutRendererTests.cs
@@ -143,7 +143,32 @@ namespace NLog.Web.Tests.LayoutRenderers
         }
 
         [Fact]
-        public void ForwardedForHeaderContainsMultipleEntriesExcessiveIndexRendersLastIndexValue()
+        public void ForwardedForHeaderContainsMultipleEntriesRendersLastValue()
+        {
+            // Arrange
+            var (renderer, httpContext) = CreateWithHttpContext();
+
+#if !ASP_NET_CORE
+            httpContext.Request.ServerVariables.Returns(new NameValueCollection {{"REMOTE_ADDR", "192.0.0.0"}});
+            httpContext.Request.Headers.Returns(
+                new NameValueCollection {{ForwardedForHeader, "192.168.1.1, 127.0.0.1"}});
+#else
+            var headers = new HeaderDict();
+            headers.Add(ForwardedForHeader, new StringValues("192.168.1.1, 127.0.0.1"));
+            httpContext.Request.Headers.Returns(callinfo => headers);
+#endif
+            renderer.CheckForwardedForHeader = true;
+            renderer.Index = -1;
+
+            // Act
+            string result = renderer.Render(new LogEventInfo());
+
+            // Assert
+            Assert.Equal("127.0.0.1", result);
+        }
+
+        [Fact]
+        public void ForwardedForHeaderContainsMultipleEntriesExcessiveIndexRendersLastValue()
         {
             // Arrange
             var (renderer, httpContext) = CreateWithHttpContext();
@@ -167,6 +192,39 @@ namespace NLog.Web.Tests.LayoutRenderers
             Assert.Equal("127.0.0.1", result);
 
             renderer.Index = 3;
+
+            // Act
+            result = renderer.Render(new LogEventInfo());
+
+            // Assert
+            Assert.Equal("127.0.0.1", result);
+        }
+
+        [Fact]
+        public void ForwardedForHeaderContainsMultipleEntriesExcessiveNegativeIndexRendersFirstValue()
+        {
+            // Arrange
+            var (renderer, httpContext) = CreateWithHttpContext();
+
+#if !ASP_NET_CORE
+            httpContext.Request.ServerVariables.Returns(new NameValueCollection {{"REMOTE_ADDR", "192.0.0.0"}});
+            httpContext.Request.Headers.Returns(
+                new NameValueCollection {{ForwardedForHeader, "127.0.0.1, 192.168.1.1"}});
+#else
+            var headers = new HeaderDict();
+            headers.Add(ForwardedForHeader, new StringValues("127.0.0.1, 192.168.1.1"));
+            httpContext.Request.Headers.Returns(callinfo => headers);
+#endif
+            renderer.CheckForwardedForHeader = true;
+            renderer.Index = -3;
+
+            // Act
+            string result = renderer.Render(new LogEventInfo());
+
+            // Assert
+            Assert.Equal("127.0.0.1", result);
+
+            renderer.Index = -4;
 
             // Act
             result = renderer.Render(new LogEventInfo());

--- a/tests/Shared/LayoutRenderers/AspNetRequestIpLayoutRendererTests.cs
+++ b/tests/Shared/LayoutRenderers/AspNetRequestIpLayoutRendererTests.cs
@@ -132,8 +132,7 @@ namespace NLog.Web.Tests.LayoutRenderers
             headers.Add(ForwardedForHeader, new StringValues("192.168.1.1, 127.0.0.1"));
             httpContext.Request.Headers.Returns(callinfo => headers);
 #endif
-            renderer.CheckForwardedForHeader = true;
-            renderer.Index = 1;
+            renderer.CheckForwardedForHeaderOffset = 1;
 
             // Act
             string result = renderer.Render(new LogEventInfo());
@@ -157,8 +156,7 @@ namespace NLog.Web.Tests.LayoutRenderers
             headers.Add(ForwardedForHeader, new StringValues("192.168.1.1, 127.0.0.1"));
             httpContext.Request.Headers.Returns(callinfo => headers);
 #endif
-            renderer.CheckForwardedForHeader = true;
-            renderer.Index = -1;
+            renderer.CheckForwardedForHeaderOffset = -1;
 
             // Act
             string result = renderer.Render(new LogEventInfo());
@@ -182,8 +180,7 @@ namespace NLog.Web.Tests.LayoutRenderers
             headers.Add(ForwardedForHeader, new StringValues("192.168.1.1, 127.0.0.1"));
             httpContext.Request.Headers.Returns(callinfo => headers);
 #endif
-            renderer.CheckForwardedForHeader = true;
-            renderer.Index = 2;
+            renderer.CheckForwardedForHeaderOffset = 2;
 
             // Act
             string result = renderer.Render(new LogEventInfo());
@@ -191,7 +188,7 @@ namespace NLog.Web.Tests.LayoutRenderers
             // Assert
             Assert.Equal("127.0.0.1", result);
 
-            renderer.Index = 3;
+            renderer.CheckForwardedForHeaderOffset = 3;
 
             // Act
             result = renderer.Render(new LogEventInfo());
@@ -215,8 +212,7 @@ namespace NLog.Web.Tests.LayoutRenderers
             headers.Add(ForwardedForHeader, new StringValues("127.0.0.1, 192.168.1.1"));
             httpContext.Request.Headers.Returns(callinfo => headers);
 #endif
-            renderer.CheckForwardedForHeader = true;
-            renderer.Index = -3;
+            renderer.CheckForwardedForHeaderOffset = -3;
 
             // Act
             string result = renderer.Render(new LogEventInfo());
@@ -224,7 +220,7 @@ namespace NLog.Web.Tests.LayoutRenderers
             // Assert
             Assert.Equal("127.0.0.1", result);
 
-            renderer.Index = -4;
+            renderer.CheckForwardedForHeaderOffset = -4;
 
             // Act
             result = renderer.Render(new LogEventInfo());


### PR DESCRIPTION
At the firm I work for, the network engineers have not followed X-Forwarded-For HHTP headers standards.
Instead of having the desired client IP at the start of the list of IP addresses in the header, the client IP is the second or third element, depending upon whether you are in development, test, or production network.

One way to solve this is to add an int Index property to the layout renderer.
