### PR TITLE
NLogRequestPostedBodyMiddleware - Fixed handling of Stream.Position

### DIFF
--- a/src/NLog.Web.AspNetCore/NLogRequestPostedBodyMiddleware.cs
+++ b/src/NLog.Web.AspNetCore/NLogRequestPostedBodyMiddleware.cs
@@ -97,12 +97,6 @@ namespace NLog.Web
                 return false;
             }
 
-            if (postedBody.Position != 0 && !postedBody.CanSeek)
-            {
-                InternalLogger.Debug("NLogRequestPostedBodyMiddleware: HttpContext.Request.Body stream position non-zero");
-                return false;
-            }
-
             return _options.ShouldCapture(context);
         }
 


### PR DESCRIPTION
```
System.NotSupportedException: Specified method is not supported.
   at Microsoft.AspNetCore.Server.IIS.Core.ReadOnlyStream.get_Position()
   at Microsoft.AspNetCore.Server.IIS.Core.WrappingStream.get_Position()
   at NLog.Web.NLogRequestPostedBodyMiddleware.ShouldCaptureRequestBody(HttpContext context)
   at NLog.Web.NLogRequestPostedBodyMiddleware.Invoke(HttpContext context)
   at Microsoft.AspNetCore.Authorization.AuthorizationMiddleware.Invoke(HttpContext ontext)
   at Swashbuckle.AspNetCore.SwaggerUI.SwaggerUIMiddleware.Invoke(HttpContext httpContext)
   at Swashbuckle.AspNetCore.Swagger.SwaggerMiddleware.Invoke(HttpContext httpContext, waggerProvider swaggerProvider)
   at Microsoft.AspNetCore.HttpLogging.HttpLoggingMiddleware.InvokeInternal(HttpContext context)
   at Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddleware.Invoke(HttpContext context)
```
See also: https://stackoverflow.com/q/76610846/193178