### PR TITLE
Update unit-test-projects to net6

### DIFF
--- a/NLog.Web.sln
+++ b/NLog.Web.sln
@@ -5,6 +5,7 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{52CA242D-DB20-41D9-8B79-A5A965ECA105}"
 	ProjectSection(SolutionItems) = preProject
 		appveyor.yml = appveyor.yml
+		azure-pipelines.yml = azure-pipelines.yml
 		build.ps1 = build.ps1
 		CHANGELOG.MD = CHANGELOG.MD
 		README.md = README.md

--- a/tests/NLog.Web.AspNetCore.Tests/NLog.Web.AspNetCore.Tests.csproj
+++ b/tests/NLog.Web.AspNetCore.Tests/NLog.Web.AspNetCore.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net461;net6.0</TargetFrameworks>
     <AssemblyName>NLog.Web.AspNetCore.Tests</AssemblyName>
     <AssemblyVersion>1.2.3.0</AssemblyVersion>
     <FileVersion>1.2.3.1</FileVersion>


### PR DESCRIPTION
To fix Azure DevOps that complains about NetCoreApp3.1

`Testhost process for source(s) 'D:\a\1\s\tests\NLog.Web.AspNetCore.Tests\bin\Release\netcoreapp3.1\NLog.Web.AspNetCore.Tests.dll' exited with error: You must install or update .NET to run this application.`