### PR TITLE
Issue 934 and 935, Middleware Initialization Debugging

### DIFF
--- a/src/NLog.Web.AspNetCore/NLogBufferingTargetWrapperMiddleware.cs
+++ b/src/NLog.Web.AspNetCore/NLogBufferingTargetWrapperMiddleware.cs
@@ -29,6 +29,8 @@ namespace NLog.Web
         public NLogBufferingTargetWrapperMiddleware(RequestDelegate next)
         {
             _next = next;
+
+            AspNetBufferingTargetWrapper.MiddlewareInstalled = true;
         }
 
         /// <summary>

--- a/src/NLog.Web.AspNetCore/NLogRequestPostedBodyMiddleware.cs
+++ b/src/NLog.Web.AspNetCore/NLogRequestPostedBodyMiddleware.cs
@@ -42,6 +42,8 @@ namespace NLog.Web
         {
             _next = next;
             _options = options ?? NLogRequestPostedBodyMiddlewareOptions.Default;
+
+            AspNetRequestPostedBodyLayoutRenderer.MiddlewareInstalled = true;
         }
 
         /// <summary>

--- a/src/NLog.Web/NLogHttpModule.cs
+++ b/src/NLog.Web/NLogHttpModule.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Web;
+using NLog.Web.Targets.Wrappers;
 
 namespace NLog.Web
 {
@@ -18,6 +19,14 @@ namespace NLog.Web
         /// Event to be raised at the beginning of each HTTP Request.
         /// </summary>
         public static event EventHandler BeginRequest;
+
+        /// <summary>
+        /// Notify the wrapper target that the correct IHttpModule is installed
+        /// </summary>
+        public NLogHttpModule()
+        {
+            AspNetBufferingTargetWrapper.MiddlewareInstalled = true;
+        }
 
         /// <summary>
         /// Initializes the HttpModule.

--- a/src/NLog.Web/NLogRequestPostedBodyModule.cs
+++ b/src/NLog.Web/NLogRequestPostedBodyModule.cs
@@ -30,6 +30,8 @@ namespace NLog.Web
         /// </summary>
         public NLogRequestPostedBodyModule()
         {
+            AspNetRequestPostedBodyLayoutRenderer.MiddlewareInstalled = true;
+
             AllowContentTypes = new List<KeyValuePair<string, string>>
             {
                 new KeyValuePair<string, string>("application/", "json"),

--- a/src/Shared/LayoutRenderers/AspNetRequestPostedBodyLayoutRenderer.cs
+++ b/src/Shared/LayoutRenderers/AspNetRequestPostedBodyLayoutRenderer.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text;
 using NLog.LayoutRenderers;
+using NLog.Common;
 #if ASP_NET_CORE
 using Microsoft.AspNetCore.Http;
 #else
@@ -17,10 +18,27 @@ namespace NLog.Web.LayoutRenderers
     [LayoutRenderer("aspnet-request-posted-body")]
     public class AspNetRequestPostedBodyLayoutRenderer : AspNetLayoutRendererBase
     {
+        internal static bool MiddlewareInstalled;
+
         /// <summary>
         /// The object for the key in HttpContext.Items for the POST request body
         /// </summary>
         internal static readonly object NLogPostedRequestBodyKey = new object();
+
+        /// <inheritdoc />
+        protected override void InitializeLayoutRenderer()
+        {
+            if (!MiddlewareInstalled)
+            {
+#if ASP_NET_CORE
+                InternalLogger.Warn("NLogRequestPostedBodyMiddleware must be installed to use aspnet-request-posted-body in a layout.");
+#else
+                InternalLogger.Warn("NLogRequestPostedBodyModule must be installed to use aspnet-request-posted-body in a layout.");
+#endif
+            }
+
+            base.InitializeLayoutRenderer();
+        }
 
         /// <inheritdoc/>
         protected override void DoAppend(StringBuilder builder, LogEventInfo logEvent)

--- a/src/Shared/LayoutRenderers/AspNetRequestPostedBodyLayoutRenderer.cs
+++ b/src/Shared/LayoutRenderers/AspNetRequestPostedBodyLayoutRenderer.cs
@@ -25,12 +25,6 @@ namespace NLog.Web.LayoutRenderers
         /// </summary>
         internal static readonly object NLogPostedRequestBodyKey = new object();
 
-        /// <inheritdoc />
-        protected override void InitializeLayoutRenderer()
-        {
-            base.InitializeLayoutRenderer();
-        }
-
         private bool _verifiedMiddlewareInstalled;
 
         /// <inheritdoc/>

--- a/src/Shared/LayoutRenderers/AspNetRequestPostedBodyLayoutRenderer.cs
+++ b/src/Shared/LayoutRenderers/AspNetRequestPostedBodyLayoutRenderer.cs
@@ -31,9 +31,9 @@ namespace NLog.Web.LayoutRenderers
             if (!MiddlewareInstalled)
             {
 #if ASP_NET_CORE
-                InternalLogger.Warn("NLogRequestPostedBodyMiddleware must be installed to use aspnet-request-posted-body in a layout.");
+                InternalLogger.Info("NLogRequestPostedBodyMiddleware is not yet initialized, which is required by aspnet-request-posted-body.");
 #else
-                InternalLogger.Warn("NLogRequestPostedBodyModule must be installed to use aspnet-request-posted-body in a layout.");
+                InternalLogger.Info("NLogRequestPostedBodyModule is not yet initialized, which is required by aspnet-request-posted-body.");
 #endif
             }
 

--- a/src/Shared/LayoutRenderers/AspNetRequestPostedBodyLayoutRenderer.cs
+++ b/src/Shared/LayoutRenderers/AspNetRequestPostedBodyLayoutRenderer.cs
@@ -31,28 +31,21 @@ namespace NLog.Web.LayoutRenderers
             base.InitializeLayoutRenderer();
         }
 
-        private static bool LogEventProcessed;
-        private static readonly object LogEventProcessedLock = new object();
+        private bool _verifiedMiddlewareInstalled;
 
         /// <inheritdoc/>
         protected override void DoAppend(StringBuilder builder, LogEventInfo logEvent)
         {
-            if (!LogEventProcessed)
+            if (!_verifiedMiddlewareInstalled)
             {
-                lock (LogEventProcessedLock)
+                _verifiedMiddlewareInstalled = true;
+                if (!MiddlewareInstalled)
                 {
-                    if (!LogEventProcessed)
-                    {
-                        LogEventProcessed = true;
-                        if (!MiddlewareInstalled)
-                        {
 #if ASP_NET_CORE
-                            InternalLogger.Info("NLogRequestPostedBodyMiddleware is not yet initialized, which is required by aspnet-request-posted-body.");
+                    InternalLogger.Info("NLogRequestPostedBodyMiddleware is not yet initialized, which is required by aspnet-request-posted-body.");
 #else
-                            InternalLogger.Info("NLogRequestPostedBodyModule is not yet initialized, which is required by aspnet-request-posted-body.");
+                    InternalLogger.Info("NLogRequestPostedBodyModule is not yet initialized, which is required by aspnet-request-posted-body.");
 #endif
-                        }
-                    }
                 }
             }
 

--- a/src/Shared/Targets/Wrappers/AspNetBufferingTargetWrapper.cs
+++ b/src/Shared/Targets/Wrappers/AspNetBufferingTargetWrapper.cs
@@ -194,8 +194,7 @@ namespace NLog.Web.Targets.Wrappers
             base.CloseTarget();
         }
 
-        private static bool LogEventProcessed;
-        private static readonly object LogEventProcessedLock = new object();
+        private bool _verifiedMiddlewareInstalled;
 
         /// <summary>
         /// Adds the specified log event to the buffer.
@@ -203,22 +202,16 @@ namespace NLog.Web.Targets.Wrappers
         /// <param name="logEvent">The log event.</param>
         protected override void WriteAsyncThreadSafe(AsyncLogEventInfo logEvent)
         {
-            if (!LogEventProcessed)
+            if (!_verifiedMiddlewareInstalled)
             {
-                lock (LogEventProcessedLock)
+                _verifiedMiddlewareInstalled = true;
+                if (!MiddlewareInstalled)
                 {
-                    if (!LogEventProcessed)
-                    {
-                        LogEventProcessed = true;
-                        if (!MiddlewareInstalled)
-                        {
 #if ASP_NET_CORE
-                            InternalLogger.Info("NLogBufferingTargetWrapperMiddleware is not yet initialized, which is required by AspNetBufferingWrapper.");
+                    InternalLogger.Info("NLogBufferingTargetWrapperMiddleware is not yet initialized, which is required by AspNetBufferingWrapper.");
 #else
-                            InternalLogger.Info("NLogHttpModule is not yet initialized, which is required by AspNetBufferingWrapper.");
+                    InternalLogger.Info("NLogHttpModule is not yet initialized, which is required by AspNetBufferingWrapper.");
 #endif
-                        }
-                    }
                 }
             }
 

--- a/src/Shared/Targets/Wrappers/AspNetBufferingTargetWrapper.cs
+++ b/src/Shared/Targets/Wrappers/AspNetBufferingTargetWrapper.cs
@@ -184,9 +184,9 @@ namespace NLog.Web.Targets.Wrappers
             if (!MiddlewareInstalled)
             {
 #if ASP_NET_CORE
-                InternalLogger.Warn("NLogBufferingTargetWrapperMiddleware must be installed to use AspNetBufferingWrapper target in the NLog.config.");
+                InternalLogger.Info("NLogBufferingTargetWrapperMiddleware is not yet initialized, which is required by AspNetBufferingWrapper.");
 #else
-                InternalLogger.Warn("NLogHttpModule must be installed to use AspNetBufferingWrapper target in the NLog.config.");
+                InternalLogger.Info("NLogHttpModule is not yet initialized, which is required by AspNetBufferingWrapper.");
 #endif
             }
 

--- a/src/Shared/Targets/Wrappers/AspNetBufferingTargetWrapper.cs
+++ b/src/Shared/Targets/Wrappers/AspNetBufferingTargetWrapper.cs
@@ -74,6 +74,8 @@ namespace NLog.Web.Targets.Wrappers
     [Target("AspNetBufferingWrapper", IsWrapper = true)]
     public class AspNetBufferingTargetWrapper : WrapperTargetBase
     {
+        internal static bool MiddlewareInstalled;
+
         private static readonly object dataSlot = new object();
         private int _bufferGrowLimit;
 
@@ -178,6 +180,15 @@ namespace NLog.Web.Targets.Wrappers
             NLogHttpModule.BeginRequest += OnBeginRequestHandler;
             NLogHttpModule.EndRequest += OnEndRequestHandler;
 #endif
+
+            if (!MiddlewareInstalled)
+            {
+#if ASP_NET_CORE
+                InternalLogger.Warn("NLogBufferingTargetWrapperMiddleware must be installed to use AspNetBufferingWrapper target in the NLog.config.");
+#else
+                InternalLogger.Warn("NLogHttpModule must be installed to use AspNetBufferingWrapper target in the NLog.config.");
+#endif
+            }
 
             base.InitializeTarget();
         }


### PR DESCRIPTION
Uses ctor for middleware and httpmodule, and initializelayoutrender/initializetarget, instead of warning every time, as requested.

Resolves #954 and resolves #935