### PR TITLE
Add support for Custom Claim management in AspNetUserClaimLayoutRenderer

### DIFF
--- a/src/Shared/LayoutRenderers/AspNetUserClaimLayoutRenderer.cs
+++ b/src/Shared/LayoutRenderers/AspNetUserClaimLayoutRenderer.cs
@@ -24,8 +24,6 @@ namespace NLog.Web.LayoutRenderers
     [LayoutRenderer("aspnet-user-claim")]
     public class AspNetUserClaimLayoutRenderer : AspNetLayoutMultiValueRendererBase
     {
-        private static readonly string[] wellKnownAuthorities = { "schemas.microsoft.com", "schemas.xmlsoap.org" };
-
         /// <summary>
         /// Key to lookup using <see cref="ClaimsIdentity.FindFirst(string)"/> with fallback to <see cref="ClaimsPrincipal.FindFirst(string)"/>
         /// </summary>

--- a/tests/Shared/LayoutRenderers/AspNetUserClaimLayoutRendererTests.cs
+++ b/tests/Shared/LayoutRenderers/AspNetUserClaimLayoutRendererTests.cs
@@ -96,6 +96,26 @@ namespace NLog.Web.Tests.LayoutRenderers
             // Assert
             Assert.Equal(expectedResult, result);
         }
+
+        [Fact]
+        public void CustomClaimFullyQualifiedRendersValue()
+        {
+            // Arrange
+            var (renderer, httpContext) = CreateWithHttpContext();
+            renderer.ClaimType = "CustomClaim.http.schemas.mycompany.com/identity/claims/myOwnName";
+
+            var expectedResult = "myOwnValue";
+            var expectedPath = "http://schemas.mycompany.com/identity/claims/myOwnName";
+            var identity = Substitute.For<System.Security.Claims.ClaimsIdentity>();
+            identity.FindFirst(expectedPath).Returns(new System.Security.Claims.Claim(expectedPath, expectedResult));
+            httpContext.User.Identity.Returns(identity);
+
+            // Act
+            string result = renderer.Render(new LogEventInfo());
+
+            // Assert
+            Assert.Equal(expectedResult, result);
+        }
     }
 }
 


### PR DESCRIPTION
## New Feature
Manage Custom Claim value in `AspNetUserClaimLayoutRenderer`

## Motivation for New Feature
This feature allows to retrieve information about the current user logged also in custom claims

## Proposed Changes
Added new prefix _CustomClaim._ in **ClaimType** 

### Description
Now the parameter **ClaimType** checks only if the value specified is _ClaimTypes._ or _ClaimType._
Adding the new prefix _CustomClaim._ in **ClaimType** you can specify your custom claim full path with the below pattern

_aspnet-user-claim:CustomClaim.**scheme**.**host**/**mypath**_

Ex.
```json
"targets": {
   "myTarget": {
      "type": "Console",
      "layout": "${date}|${level}|${aspnet-user-claim:CustomClaim.http.schemas.mycompany.com/identity/claims/myclaim}"
   }
}
```

**NLog version**: 5.2.7

**NLog.Web / NLog.Web.AspNetCore version**: 5.3.7

**NLog.Extensions.Logging version**: 5.3.7

**Platform**: .Net 3.5 / .Net 4.6 / .NET Core 3.1 / .NET 6.0

Issue Reference #1016 