### PR TITLE
Version 6.2

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,6 +4,15 @@ See also [releases](https://github.com/NLog/NLog.Web/releases) and [milestones](
 
 Date format: (year/month/day)
 
+### Version 6.2 (2026/08/16)
+
+- **NLog.Web.AspNetCore**
+  - [#1178](https://github.com/NLog/NLog.Web/pull/1178) Updated dependency NLog v6.2 (@snakefoot)
+  - [#1162](https://github.com/NLog/NLog.Web/pull/1162) Updated tutorials and examples for using NLog with ASP.NET Core (@snakefoot)
+
+- **NLog.Web**
+  - [#1178](https://github.com/NLog/NLog.Web/pull/1178) Updated dependency NLog v6.2 (@snakefoot)
+
 ### Version 6.1.4 (2026/07/08)
 
 - **NLog.Web.AspNetCore**

--- a/build.ps1
+++ b/build.ps1
@@ -2,7 +2,7 @@
 # creates NuGet package at \artifacts
 dotnet --version
 
-$versionPrefix = "6.1.4"
+$versionPrefix = "6.2.0"
 $versionSuffix = ""
 $versionFile = $versionPrefix + "." + ${env:APPVEYOR_BUILD_NUMBER}
 if ($env:APPVEYOR_PULL_REQUEST_NUMBER) {

--- a/examples/ASP.NET 4.6.1/Visual Studio 2017/ASP.NET 4.6.1 - VS2017/ASP.NET 4.6.1 - VS2017.csproj
+++ b/examples/ASP.NET 4.6.1/Visual Studio 2017/ASP.NET 4.6.1 - VS2017/ASP.NET 4.6.1 - VS2017.csproj
@@ -49,7 +49,7 @@
       <HintPath>..\..\..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=6.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\NLog.6.1.4\lib\net46\NLog.dll</HintPath>
+      <HintPath>..\..\..\..\packages\NLog.6.2.0\lib\net46\NLog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/examples/ASP.NET 4.6.1/Visual Studio 2017/ASP.NET 4.6.1 - VS2017/packages.config
+++ b/examples/ASP.NET 4.6.1/Visual Studio 2017/ASP.NET 4.6.1 - VS2017/packages.config
@@ -11,6 +11,6 @@
   <package id="Microsoft.jQuery.Unobtrusive.Validation" version="3.2.12" targetFramework="net461" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net461" />
   <package id="Modernizr" version="2.8.3" targetFramework="net461" />
-  <package id="NLog" version="6.1.4" targetFramework="net461" />
+  <package id="NLog" version="6.2.0" targetFramework="net461" />
   <package id="WebGrease" version="1.6.0" targetFramework="net461" />
 </packages>

--- a/src/NLog.Web.AspNetCore/NLog.Web.AspNetCore.csproj
+++ b/src/NLog.Web.AspNetCore/NLog.Web.AspNetCore.csproj
@@ -16,8 +16,8 @@ Integrates NLog as provider for Microsoft.Extensions.Logging, and provides NLog 
     <PackageReleaseNotes>
 ChangeLog:
 
-- [#1151] Updated dependency NLog v6.1.4 (@snakefoot)
-- [#1145] AppVeyor - Visual Studio 2026 (@snakefoot)
+- [#1178] Updated dependency NLog v6.2 (@snakefoot)
+- [#1162] Updated tutorials and examples for using NLog with ASP.NET Core (@snakefoot)
 
 List of major changes in NLog v6.0: https://nlog-project.org/2025/04/29/nlog-6-0-major-changes.html
 
@@ -72,7 +72,7 @@ List of available Layout Renderers: https://nlog-project.org/config/?tab=layout-
     <AssemblyTitle>$(Title)</AssemblyTitle>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NLog.Extensions.Logging" Version="6.1.4" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="6.2.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.400" PrivateAssets="All" />
   </ItemGroup>
   

--- a/src/NLog.Web/NLog.Web.csproj
+++ b/src/NLog.Web/NLog.Web.csproj
@@ -71,8 +71,8 @@ List of available Layout Renderers: https://nlog-project.org/config/?tab=layout-
     <DownloadFile SourceUrl="https://nlog-project.org/N.png" DestinationFolder="$(MSBuildThisFileDirectory)" />
   </Target>
   <ItemGroup>
-    <PackageReference Include="NLog" Version="6.1.4" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All" />
+    <PackageReference Include="NLog" Version="6.2.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.400" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Web" />

--- a/tests/NLog.Web.AspNetCore.Tests/NLog.Web.AspNetCore.Tests.csproj
+++ b/tests/NLog.Web.AspNetCore.Tests/NLog.Web.AspNetCore.Tests.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\NLog.Web.AspNetCore\NLog.Web.AspNetCore.csproj" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
@@ -27,7 +27,7 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' or '$(TargetFramework)' == 'net462' ">
-    <PackageReference Include="System.ValueTuple" Version="4.6.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.6.2" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.3.6" />
     <PackageReference Include="System.Formats.Asn1" Version="8.0.1" />

--- a/tests/NLog.Web.Tests/NLog.Web.Tests.csproj
+++ b/tests/NLog.Web.Tests/NLog.Web.Tests.csproj
@@ -12,9 +12,9 @@
     <AssemblyOriginatorKeyFile>../../NLog.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.6.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.6.2" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
- https://github.com/NLog/NLog/releases/tag/v6.2.0

Release notes for NLog v6.2: https://nlog-project.org/2026/08/16/nlog-6-2-aot-build-size.html